### PR TITLE
limits the async-http-client version to <1.9, fixes #79

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '[4.3,5.0['
     testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '[1.45,1.99999)'
     testCompile group: 'commons-lang', name: 'commons-lang', version: '[2.6,2.99999)'
-    compile group: 'com.ning', name: 'async-http-client', version: '[1.6.1,1.9)'
+    compile group: 'com.ning', name: 'async-http-client', version: '[1.6.1,1.9['
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '[2.3.1,2.99999)'
     compile group: 'commons-validator', name: 'commons-validator', version: '[1.4.0,1.99999)'
     compile group: 'commons-codec', name: 'commons-codec', version: '[1.9,1.99999]'


### PR DESCRIPTION
no way to test this, but the output of `./gradlew build --refresh-dependencies && ./gradlew dependencies` contains the following tree:

```
compile - Compile classpath for source set 'main'.
+--- com.ning:async-http-client:[1.6.1,1.9[ -> 1.8.16
|    +--- io.netty:netty:3.9.2.Final
|    \--- org.slf4j:slf4j-api:1.7.5
+--- com.fasterxml.jackson.core:jackson-databind:[2.3.1,2.99999) -> 2.6.1
|    +--- com.fasterxml.jackson.core:jackson-annotations:2.6.0
|    \--- com.fasterxml.jackson.core:jackson-core:2.6.1
+--- commons-validator:commons-validator:[1.4.0,1.99999) -> 1.4.1
|    +--- commons-beanutils:commons-beanutils:1.8.3
|    |    \--- commons-logging:commons-logging:1.1.1 -> 1.2
|    +--- commons-digester:commons-digester:1.8.1
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-collections:commons-collections:3.2.1
\--- commons-codec:commons-codec:[1.9,1.99999] -> 1.10
```