### PR TITLE
MODIFY Expose HTTP client configuration

### DIFF
--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -29,6 +29,8 @@ import com.opentok.util.HttpClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.ning.http.client.AsyncHttpClientConfig;
+
 import org.xml.sax.InputSource;
 
 /**
@@ -64,9 +66,13 @@ public class OpenTok {
     }
 
     public OpenTok(int apiKey, String apiSecret, String apiUrl) {
+        this(apiKey, apiSecret, apiUrl, null);
+    }
+    
+    public OpenTok(int apiKey, String apiSecret, String apiUrl, AsyncHttpClientConfig httpConfig) {
         this.apiKey = apiKey;
         this.apiSecret = apiSecret.trim();
-        this.client = new HttpClient.Builder(apiKey, apiSecret)
+        this.client = new HttpClient.Builder(apiKey, apiSecret, httpConfig)
                 .apiUrl(apiUrl)
                 .build();
     }

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -287,10 +287,16 @@ public class HttpClient extends AsyncHttpClient {
         private final String apiSecret;
         private String apiUrl;
         private AsyncHttpClientConfig config;
+        private AsyncHttpClientConfig configPrototype;
 
-        public Builder(int apiKey, String apiSecret) {
+        public Builder(int apiKey, String apiSecret, AsyncHttpClientConfig prototype) {
             this.apiKey = apiKey;
             this.apiSecret = apiSecret;
+            this.configPrototype = prototype;
+        }
+    
+        public Builder(int apiKey, String apiSecret) {
+            this(apiKey, apiSecret, null);
         }
 
         public Builder apiUrl(String apiUrl) {
@@ -299,7 +305,14 @@ public class HttpClient extends AsyncHttpClient {
         }
 
         public HttpClient build() {
-            this.config = new AsyncHttpClientConfig.Builder()
+            AsyncHttpClientConfig.Builder builder;
+            if (null != this.configPrototype) {
+                builder = new AsyncHttpClientConfig.Builder(this.configPrototype); 
+            } else {
+                builder = new AsyncHttpClientConfig.Builder();
+            }
+        
+            this.config = builder
                     .setUserAgent("Opentok-Java-SDK/" + Version.VERSION + " JRE/" + System.getProperty("java.version"))
                     .addRequestFilter(new PartnerAuthRequestFilter(this.apiKey, this.apiSecret))
                     .build();


### PR DESCRIPTION
Proxy configuration settings can be configured by passing an HTTP client config
prototype into the SDK client. Most other attributes available in
AsyncHttpClientConfig.Builder are also free to modify, except for those
overridden by the OpenTok SDK itself (namely useragent and headers).

Fixes #53
r=aoberoi
