### PR TITLE
[WIP] proxy support, fixes #53

### DIFF
--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -10,6 +10,7 @@ package com.opentok;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.net.Proxy;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +51,7 @@ public class OpenTok {
             .reader(Archive.class);
     static protected ObjectReader archiveListReader = new ObjectMapper()
             .reader(ArchiveList.class);
+    static final String defaultApiUrl = "https://api.opentok.com";
 
     /**
      * Creates an OpenTok object.
@@ -60,15 +62,25 @@ public class OpenTok {
      * page.)
      */
     public OpenTok(int apiKey, String apiSecret) {
-        this(apiKey, apiSecret, "https://api.opentok.com");
+        this(apiKey, apiSecret, defaultApiUrl);
     }
 
     public OpenTok(int apiKey, String apiSecret, String apiUrl) {
+        this(apiKey, apiSecret, apiUrl, null);
+    }
+
+    public OpenTok(int apiKey, String apiSecret, String apiUrl, Proxy proxy) {
         this.apiKey = apiKey;
         this.apiSecret = apiSecret.trim();
-        this.client = new HttpClient.Builder(apiKey, apiSecret)
-                .apiUrl(apiUrl)
-                .build();
+        if (apiUrl == null) {
+            apiUrl = defaultApiUrl;
+        }
+        HttpClient.Builder clientBuilder = new HttpClient.Builder(apiKey, apiSecret)
+                .apiUrl(apiUrl);
+        if (proxy != null) {
+            clientBuilder.proxy(proxy);
+        }
+        this.client = clientBuilder.build();
     }
 
     /**


### PR DESCRIPTION
adds another overloaded form of the `OpenTok` constructor to enable support for proxies. 

- [x] validate that HTTP(S)-only proxies with no authentication meets the immediate needs
- [x] add test coverage

i am favoring this approach over #100 because that would tightly couple the API of this project to that of AsyncHttpClient project since the additional constructor parameter is typed as a `AsyncHttpClientConfig`. alternatively, this approach only couples to the API that is a part of the standard JDK library, `java.net.Proxy`. this makes this project's API footprint much, much smaller, which makes it easier to maintain compatibility for all the users. this was important because there is a possibility that we swap the HTTP client implementation from AsyncHttpClient to another project like okhttp.

an example of using the new feature would be:

```java
try {
    opentok = new OpenTok(Integer.parseInt(apiKey), apiSecret, null, new Proxy(Proxy.Type.HTTP, new InetSocketAddress(InetAddress.getLocalHost(), 3128)));
} catch (UnknownHostException e) {
    e.printStackTrace();
}
```

@davideberlein i'd like some feedback about the first item on the todo list from you.

as for the second item, i validated that the code works using the squid http proxy locally, and by modifying the HelloWorld sample application. i need to spend a little time to figure out how to test the change.