### PR TITLE
Prefer JSON format response while creating an Opentok session

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ String token = session.generateToken(new TokenOptions.Builder()
 
 You can start the recording of an OpenTok Session using a `com.opentok.OpenTok` instance's
 `startArchive(String sessionId, String name)` method. This will return a `com.opentok.Archive` instance.
-The parameter `name` is a optional and used to assign a name for the Archive. Note that you can
+The parameter `name` is optional and used to assign a name for the Archive. Note that you can
 only start an Archive on a Session that has clients connected.
 
 ```java

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
+apply plugin: 'license'
 
 group = 'com.tokbox'
 archivesBaseName = 'opentok-server-sdk'
@@ -49,7 +50,6 @@ dependencies {
     //compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.5'
 }
 
-apply plugin: 'license'
 license {
     header rootProject.file('codequality/HEADER')
     ext.year = Calendar.getInstance().get(Calendar.YEAR)

--- a/src/main/java/com/opentok/Archive.java
+++ b/src/main/java/com/opentok/Archive.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
-* Represents an archive of an OpenTok session. 
+* Represents an archive of an OpenTok session.
 */
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class Archive {
@@ -160,7 +160,7 @@ public class Archive {
         return sessionId;
     }
 
-    /** 
+    /**
      * The size of the MP4 file. For archives that have not been generated, this value is set to 0.
      */
     public int getSize() {
@@ -176,7 +176,7 @@ public class Archive {
 
     /**
      * The download URL of the available MP4 file. This is only set for an archive with the status
-     * set to Status.AVAILABLE; for other archives, (including archives with the status of 
+     * set to Status.AVAILABLE; for other archives, (including archives with the status of
      * Status.UPLOADED) this method returns null. The download URL is obfuscated, and the file
      * is only available from the URL for 10 minutes. To generate a new URL, call the
      * {@link com.opentok.OpenTok#listArchives()} or {@link com.opentok.OpenTok#getArchive(String)}
@@ -201,7 +201,7 @@ public class Archive {
     }
 
     /**
-     * The output mode to be generated for this archive: <code>composed</code> or <code>individual</code>. 
+     * The output mode to be generated for this archive: <code>composed</code> or <code>individual</code>.
      */
     public OutputMode getOutputMode() {
         return outputMode;
@@ -214,7 +214,7 @@ public class Archive {
         } catch (Exception e) {
             return "";
         }
-        
+
     }
 
 }

--- a/src/main/java/com/opentok/ArchiveList.java
+++ b/src/main/java/com/opentok/ArchiveList.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/ArchiveMode.java
+++ b/src/main/java/com/opentok/ArchiveMode.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/ArchiveProperties.java
+++ b/src/main/java/com/opentok/ArchiveProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/CreatedSession.java
+++ b/src/main/java/com/opentok/CreatedSession.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/CreatedSession.java
+++ b/src/main/java/com/opentok/CreatedSession.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreatedSession {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     @JsonProperty("session_id")
     private String sessionId;
 
@@ -25,7 +27,7 @@ public class CreatedSession {
     private String projectId;
 
     @JsonProperty("partner_id")
-    private String partner_id;
+    private String partnerId;
 
     @JsonProperty("create_dt")
     private String createDt;
@@ -50,7 +52,7 @@ public class CreatedSession {
     }
 
     public String getPartnerId() {
-        return partner_id;
+        return partnerId;
     }
 
     public String getCreateDt() {
@@ -64,7 +66,7 @@ public class CreatedSession {
     @Override
     public String toString() {
         try {
-            return new ObjectMapper().writeValueAsString(this);
+            return OBJECT_MAPPER.writeValueAsString(this);
         } catch (Exception e) {
             return "";
         }

--- a/src/main/java/com/opentok/CreatedSession.java
+++ b/src/main/java/com/opentok/CreatedSession.java
@@ -1,0 +1,73 @@
+/**
+ * OpenTok Java SDK
+ * Copyright (C) 2016 TokBox, Inc.
+ * http://www.tokbox.com
+ *
+ * Licensed under The MIT License (MIT). See LICENSE file for more information.
+ */
+package com.opentok;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Represents a generated OpenTok session via REST API.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreatedSession {
+
+    @JsonProperty("session_id")
+    private String sessionId;
+
+    @JsonProperty("project_id")
+    private String projectId;
+
+    @JsonProperty("partner_id")
+    private String partner_id;
+
+    @JsonProperty("create_dt")
+    private String createDt;
+
+    @JsonProperty("media_server_url")
+    private String mediaServerURL;
+
+    protected CreatedSession() {
+    }
+
+    @JsonCreator
+    public static CreatedSession makeSession() {
+        return new CreatedSession();
+    }
+
+    public String getId() {
+        return sessionId;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public String getPartnerId() {
+        return partner_id;
+    }
+
+    public String getCreateDt() {
+        return createDt;
+    }
+
+    public String getMediaServerURL() {
+        return mediaServerURL;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return new ObjectMapper().writeValueAsString(this);
+        } catch (Exception e) {
+            return "";
+        }
+
+    }
+}

--- a/src/main/java/com/opentok/MediaMode.java
+++ b/src/main/java/com/opentok/MediaMode.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -15,14 +15,8 @@ import com.opentok.exception.OpenTokException;
 import com.opentok.exception.RequestException;
 import com.opentok.util.Crypto;
 import com.opentok.util.HttpClient;
-import com.opentok.util.TokenGenerator;
-import org.xml.sax.InputSource;
 
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
-import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.Proxy;
 import java.util.Collection;
@@ -48,6 +42,8 @@ public class OpenTok {
             .readerFor(Archive.class);
     static protected ObjectReader archiveListReader = new ObjectMapper()
             .readerFor(ArchiveList.class);
+    static protected ObjectReader createdSessionReader = new ObjectMapper()
+            .readerFor(CreatedSession[].class);
     static final String defaultApiUrl = "https://api.opentok.com";
 
     /**
@@ -238,25 +234,19 @@ public class OpenTok {
      * session. You will use this session ID in the client SDKs to identify the session.
      */
     public Session createSession(SessionProperties properties) throws OpenTokException {
-        Map<String, Collection<String>> params;
-        String xpathQuery = "/sessions/Session/session_id";
+        final SessionProperties _properties = properties != null ? properties : new SessionProperties.Builder().build();
+        final Map<String, Collection<String>> params = _properties.toMap();
+        final String response = this.client.createSession(params);
 
-        // NOTE: doing this null check twice is kind of ugly
-        params = properties != null ? properties.toMap() :
-                new SessionProperties.Builder().build().toMap();
-        
-        String xmlResponse = this.client.createSession(params);
-
-
-        // NOTE: doing this null check twice is kind of ugly
         try {
-            if (properties != null) {
-                return new Session(readXml(xpathQuery, xmlResponse), apiKey, apiSecret, properties);
-            } else {
-                return new Session(readXml(xpathQuery, xmlResponse), apiKey, apiSecret);
+            CreatedSession[] sessions = createdSessionReader.readValue(response);
+            // A bit ugly, but API response should include an array with one session
+            if (sessions.length != 1) {
+                throw new OpenTokException(String.format("Unexpected number of sessions created %d", sessions.length));
             }
-        } catch (XPathExpressionException e) {
-            throw new OpenTokException("Cannot create session. Could not read the response: " + xmlResponse);
+            return new Session(sessions[0].getId(), apiKey, apiSecret, _properties);
+        } catch (IOException e) {
+            throw new OpenTokException("Cannot create session. Could not read the response: " + response);
         }
     }
 
@@ -300,13 +290,6 @@ public class OpenTok {
      */
     public Session createSession() throws OpenTokException {
         return createSession(null);
-    }
-
-    private static String readXml(String xpathQuery, String xml) throws XPathExpressionException {
-        XPathFactory xpathFactory = XPathFactory.newInstance();
-        XPath xpath = xpathFactory.newXPath();
-        InputSource source = new InputSource(new StringReader(xml));
-        return xpath.evaluate(xpathQuery, source);
     }
 
     /**

--- a/src/main/java/com/opentok/Role.java
+++ b/src/main/java/com/opentok/Role.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/Session.java
+++ b/src/main/java/com/opentok/Session.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/SessionProperties.java
+++ b/src/main/java/com/opentok/SessionProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/TokenOptions.java
+++ b/src/main/java/com/opentok/TokenOptions.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/constants/DefaultApiUrl.java
+++ b/src/main/java/com/opentok/constants/DefaultApiUrl.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/constants/Version.java
+++ b/src/main/java/com/opentok/constants/Version.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/constants/package-info.java
+++ b/src/main/java/com/opentok/constants/package-info.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/exception/InvalidArgumentException.java
+++ b/src/main/java/com/opentok/exception/InvalidArgumentException.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/exception/OpenTokException.java
+++ b/src/main/java/com/opentok/exception/OpenTokException.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/exception/RequestException.java
+++ b/src/main/java/com/opentok/exception/RequestException.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/exception/package-info.java
+++ b/src/main/java/com/opentok/exception/package-info.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/package-info.java
+++ b/src/main/java/com/opentok/package-info.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/util/Crypto.java
+++ b/src/main/java/com/opentok/util/Crypto.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -48,6 +48,7 @@ public class HttpClient extends AsyncHttpClient {
 
         Future<Response> request = this.preparePost(this.apiUrl + "/session/create")
                 .setFormParams(paramsString)
+                .addHeader("Accept", "application/json") // XML version is deprecated
                 .execute();
 
         try {

--- a/src/main/java/com/opentok/util/TokenGenerator.java
+++ b/src/main/java/com/opentok/util/TokenGenerator.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/test/java/com/opentok/test/Helpers.java
+++ b/src/test/java/com/opentok/test/Helpers.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2016 TokBox, Inc.
+ * Copyright (C) 2017 TokBox, Inc.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -103,10 +103,11 @@ public class OpenTokTest {
         stubFor(post(urlEqualTo(SESSION_CREATE))
                 .willReturn(aResponse()
                         .withStatus(200)
-                        .withHeader("Content-Type", "text/xml")
-                        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><sessions><Session><" +
-                                "session_id>" + sessionId + "</session_id><partner_id>123456</partner_id><create_dt>" +
-                                "Mon Mar 17 00:41:31 PDT 2014</create_dt></Session></sessions>")));
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"session_id\":\"" + sessionId + "\",\"project_id\":\"00000000\"," +
+                                "\"partner_id\":\"123456\"," +
+                                "\"create_dt\":\"Mon Mar 17 00:41:31 PDT 2014\"," +
+                                "\"media_server_url\":\"\"}]")));
 
         Session session = sdk.createSession();
 
@@ -131,10 +132,11 @@ public class OpenTokTest {
         stubFor(post(urlEqualTo(SESSION_CREATE))
                 .willReturn(aResponse()
                         .withStatus(200)
-                        .withHeader("Content-Type", "text/xml")
-                        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><sessions><Session><" +
-                                "session_id>" + sessionId + "</session_id><partner_id>123456</partner_id><create_dt>" +
-                                "Mon Mar 17 00:41:31 PDT 2014</create_dt></Session></sessions>")));
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"session_id\":\"" + sessionId + "\",\"project_id\":\"00000000\"," +
+                                "\"partner_id\":\"123456\"," +
+                                "\"create_dt\":\"Mon Mar 17 00:41:31 PDT 2014\"," +
+                                "\"media_server_url\":\"\"}]")));
 
         SessionProperties properties = new SessionProperties.Builder()
                 .mediaMode(MediaMode.ROUTED)
@@ -162,10 +164,11 @@ public class OpenTokTest {
         stubFor(post(urlEqualTo(SESSION_CREATE))
                 .willReturn(aResponse()
                         .withStatus(200)
-                        .withHeader("Content-Type", "text/xml")
-                        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><sessions><Session><" +
-                                "session_id>" + sessionId + "</session_id><partner_id>123456</partner_id><create_dt>" +
-                                "Mon Mar 17 00:41:31 PDT 2014</create_dt></Session></sessions>")));
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"session_id\":\"" + sessionId + "\",\"project_id\":\"00000000\"," +
+                                "\"partner_id\":\"123456\"," +
+                                "\"create_dt\":\"Mon Mar 17 00:41:31 PDT 2014\"," +
+                                "\"media_server_url\":\"\"}]")));
 
         SessionProperties properties = new SessionProperties.Builder()
                 .location(locationHint)
@@ -193,10 +196,11 @@ public class OpenTokTest {
         stubFor(post(urlEqualTo(SESSION_CREATE))
                 .willReturn(aResponse()
                         .withStatus(200)
-                        .withHeader("Content-Type", "text/xml")
-                        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><sessions><Session><" +
-                                "session_id>" + sessionId + "</session_id><partner_id>123456</partner_id><create_dt>" +
-                                "Mon Mar 17 00:41:31 PDT 2014</create_dt></Session></sessions>")));
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"session_id\":\"" + sessionId + "\",\"project_id\":\"00000000\"," +
+                                "\"partner_id\":\"123456\"," +
+                                "\"create_dt\":\"Mon Mar 17 00:41:31 PDT 2014\"," +
+                                "\"media_server_url\":\"\"}]")));
 
         SessionProperties properties = new SessionProperties.Builder()
                 .archiveMode(ArchiveMode.ALWAYS)
@@ -885,11 +889,11 @@ public class OpenTokTest {
         stubFor(post(urlEqualTo("/session/create"))
                 .willReturn(aResponse()
                         .withStatus(200)
-                        .withHeader("Content-Type", "text/xml")
-                        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><sessions><Session><" +
-                                "session_id>" + sessionId + "</session_id><partner_id>123456</partner_id><create_dt>" +
-                                "Mon Mar 17 00:41:31 PDT 2014</create_dt></Session></sessions>")
-                        ));
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"session_id\":\"" + sessionId + "\",\"project_id\":\"00000000\"," +
+                                "\"partner_id\":\"123456\"," +
+                                "\"create_dt\":\"Mon Mar 17 00:41:31 PDT 2014\"," +
+                                "\"media_server_url\":\"\"}]")));
 
         Session session = sdk.createSession();
 


### PR DESCRIPTION
We're aiming to use this library in the near future for our integration with Opentok. While checking the code I saw that this SDK is still using the deprecated XML format for generating a session.

This PR includes a suggestion for preferring JSON format instead of XML.

thanks!
