### PR TITLE
Add proxy authentication support, fixes #102

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ dist: trusty
 language: java
 matrix:
   include:
-  - dist: precise
-    jdk: oraclejdk8
+  - jdk: oraclejdk8
   - jdk: openjdk8
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: java
 matrix:
   include:
   - dist: precise
-    jdk: openjdk7
-  - dist: precise
-    jdk: oraclejdk7
+    jdk: oraclejdk8
   - jdk: openjdk8
   - jdk: oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
   - dist: precise
     jdk: oraclejdk8
   - jdk: openjdk8
-  - jdk: oraclejdk8
 
 notifications:
   slack:

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Reference documentation is available at
 You need an OpenTok API key and API secret, which you can obtain by logging into your
 [TokBox account](https://tokbox.com/account).
 
-The OpenTok Java SDK requires JDK 6 or greater to compile. Runtime requires Java SE 6 or greater.
+The OpenTok Java SDK requires JDK 8 or greater to compile. Runtime requires Java SE 8 or greater.
 This project is tested on both OpenJDK and Oracle implementations.
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '[4.3,5.0['
     testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '[1.45,1.99999)'
     compile group: 'commons-lang', name: 'commons-lang', version: '[2.6,2.99999)'
-    compile group: 'com.ning', name: 'async-http-client', version: '[1.9,2.0['
+    compile group: 'org.asynchttpclient', name: 'async-http-client', version: '2.0.34'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '[2.3.1,2.99999)'
     compile group: 'commons-validator', name: 'commons-validator', version: '[1.4.0,1.99999)'
     compile group: 'commons-codec', name: 'commons-codec', version: '[1.9,1.99999]'
@@ -130,14 +130,14 @@ test {
     maxHeapSize = "1024m"
 }
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 // credit: http://stackoverflow.com/a/22681854/305340
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-Xlint:deprecation" << "-Xlint:unchecked"
     doFirst {
-        if (System.env.JDK7_HOME != null) {
-            options.bootClasspath = "$System.env.JDK7_HOME/jre/lib/rt.jar"
-            options.bootClasspath += "$File.pathSeparator$System.env.JDK7_HOME/jre/lib/jce.jar"
+        if (System.env.JDK8_HOME != null) {
+            options.bootClasspath = "$System.env.JDK8_HOME/jre/lib/rt.jar"
+            options.bootClasspath += "$File.pathSeparator$System.env.JDK8_HOME/jre/lib/jce.jar"
             // and other specific JDK jars
         }
     }

--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -15,6 +15,7 @@ import com.opentok.exception.OpenTokException;
 import com.opentok.exception.RequestException;
 import com.opentok.util.Crypto;
 import com.opentok.util.HttpClient;
+import com.opentok.util.HttpClient.ProxyAuthScheme;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -421,6 +422,7 @@ public class OpenTok {
         private String apiSecret;
         private String apiUrl;
         private Proxy proxy;
+        private ProxyAuthScheme proxyAuthScheme;
         private String principal;
         private String password;
         
@@ -435,12 +437,13 @@ public class OpenTok {
         }
         
         public Builder proxy(Proxy proxy) {
-            proxy(proxy, null, null);
+            proxy(proxy, null, null, null);
             return this;
         }
         
-        public Builder proxy(Proxy proxy, String principal, String password) {
+        public Builder proxy(Proxy proxy, ProxyAuthScheme proxyAuthScheme, String principal, String password) {
             this.proxy = proxy;
+            this.proxyAuthScheme = proxyAuthScheme;
             this.principal = principal;
             this.password = password;
             return this;
@@ -453,7 +456,7 @@ public class OpenTok {
                 clientBuilder.apiUrl(this.apiUrl);
             }
             if (this.proxy != null) {
-                clientBuilder.proxy(this.proxy, principal, password);
+                clientBuilder.proxy(this.proxy, proxyAuthScheme, principal, password);
             }
             
             return new OpenTok(this.apiKey, this.apiSecret, clientBuilder.build());

--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -421,6 +421,8 @@ public class OpenTok {
         private String apiSecret;
         private String apiUrl;
         private Proxy proxy;
+        private String principal;
+        private String password;
         
         public Builder(int apiKey, String apiSecret) {
             this.apiKey = apiKey;
@@ -433,7 +435,14 @@ public class OpenTok {
         }
         
         public Builder proxy(Proxy proxy) {
+            proxy(proxy, null, null);
+            return this;
+        }
+        
+        public Builder proxy(Proxy proxy, String principal, String password) {
             this.proxy = proxy;
+            this.principal = principal;
+            this.password = password;
             return this;
         }
         
@@ -444,7 +453,7 @@ public class OpenTok {
                 clientBuilder.apiUrl(this.apiUrl);
             }
             if (this.proxy != null) {
-                clientBuilder.proxy(this.proxy);
+                clientBuilder.proxy(this.proxy, principal, password);
             }
             
             return new OpenTok(this.apiKey, this.apiSecret, clientBuilder.build());

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -255,6 +255,8 @@ public class HttpClient extends AsyncHttpClient {
         private final int apiKey;
         private final String apiSecret;
         private Proxy proxy;
+        private String principal;
+        private String password;
         private String apiUrl;
         private AsyncHttpClientConfig config;
 
@@ -269,7 +271,14 @@ public class HttpClient extends AsyncHttpClient {
         }
 
         public Builder proxy(Proxy proxy) {
+            proxy(proxy, null, null);
+            return this;
+        }
+        
+        public Builder proxy(Proxy proxy, String principal, String password) {
             this.proxy = proxy;
+            this.principal = principal;
+            this.password = password;
             return this;
         }
 
@@ -283,6 +292,17 @@ public class HttpClient extends AsyncHttpClient {
             
             if (this.proxy != null) {
                 configBuilder.setProxyServer(createProxyServer(this.proxy));
+            }
+            
+            if (this.principal != null) {
+                Realm.RealmBuilder rb = new Realm.RealmBuilder();
+                rb.setScheme(Realm.AuthScheme.BASIC);
+                rb.setUsePreemptiveAuth(true);
+                rb.setTargetProxy(true);
+                rb.setPrincipal(this.principal);
+                rb.setPassword(this.password);
+
+                configBuilder.setRealm(rb.build());
             }
             
             this.config = configBuilder.build();
@@ -307,7 +327,7 @@ public class HttpClient extends AsyncHttpClient {
             }
 
             InetSocketAddress isa = (InetSocketAddress) sa;
-
+            
             final String isaHost = isa.isUnresolved() ? isa.getHostName() : isa.getAddress().getHostAddress();
             return new ProxyServer(isaHost, isa.getPort());
         }

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -168,7 +168,7 @@ public class HttpClient extends DefaultAsyncHttpClient {
                     throw new RequestException("Could not get an OpenTok Archive. The server response was invalid."
                             + " response code: " + response.getStatusCode());
             }
-        } catch (InterruptedException | ExecutionException | IOException e) {
+        } catch (InterruptedException | ExecutionException e) {
             throw new RequestException("Could not get OpenTok Archives", e);
         }
     }


### PR DESCRIPTION
Initial implementation to support forward proxies with authentication.

Some notes:
* The AHC 1.9 branch is having an issue regarding proxy authentication: https://github.com/AsyncHttpClient/async-http-client/issues/996 - In order to get it working I had to upgrade to the AHC 2.0 branch
* AHC 2.0 requires JDK8. Thus I increased the sourceCompatibility level to 1.8

I am aware that this may be a difficult requirement, yet it was required to make it work. The workaround in https://github.com/AsyncHttpClient/async-http-client/issues/996#issuecomment-172879211 did not work out eventually - at least not with the test setup I had locally (Apache forward proxy with basic authentication).

Looking forward to your feedback.