### PR TITLE
Added support for describing archive layouts for composed archives, addresses #131

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ You need an OpenTok API key and API secret, which you can obtain by logging into
 The OpenTok Java SDK requires JDK 8 or greater to compile. Runtime requires Java SE 8 or greater.
 This project is tested on both OpenJDK and Oracle implementations.
 
+For Java 7 please use OpenTok Java SDK v3.
 
 # Release Notes
 

--- a/src/main/java/com/opentok/ArchiveLayout.java
+++ b/src/main/java/com/opentok/ArchiveLayout.java
@@ -1,3 +1,10 @@
+/**
+ * OpenTok Java SDK
+ * Copyright (C) 2017 TokBox, Inc.
+ * http://www.tokbox.com
+ *
+ * Licensed under The MIT License (MIT). See LICENSE file for more information.
+ */
 package com.opentok;
 
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/src/main/java/com/opentok/ArchiveLayout.java
+++ b/src/main/java/com/opentok/ArchiveLayout.java
@@ -1,0 +1,55 @@
+package com.opentok;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@JsonFormat(shape= JsonFormat.Shape.OBJECT)
+public class ArchiveLayout {
+    private Type type;
+    private String stylesheet;
+
+    public ArchiveLayout(Type type, String stylesheet) {
+        this.type = type;
+        this.stylesheet = stylesheet;
+    }
+
+    public ArchiveLayout(Type type) {
+        this.type = type;
+    }
+
+    public enum Type {
+        PIP("pip"),
+        BESTFIT("bestFit"),
+        VERTICAL("verticalPresentation"),
+        HORIZONTAL("horizontalPresentation"),
+        CUSTOM("custom");
+
+        private String serialized;
+
+        private Type(String s) {
+            serialized = s;
+        }
+
+        @JsonValue
+        public String toString() {
+            return super.toString().toLowerCase();
+        }
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public String getStylesheet() {
+        return stylesheet;
+    }
+
+    public void setStylesheet(String stylesheet) {
+        this.stylesheet = stylesheet;
+    }
+
+}

--- a/src/main/java/com/opentok/ArchiveLayout.java
+++ b/src/main/java/com/opentok/ArchiveLayout.java
@@ -3,6 +3,10 @@ package com.opentok;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ *  Represents a <a href="https://tokbox.com/developer/guides/archiving/layout-control.html">layout configuration</a>
+ *  for a composed archive
+ */
 @JsonFormat(shape= JsonFormat.Shape.OBJECT)
 public class ArchiveLayout {
     private Type type;

--- a/src/main/java/com/opentok/ArchiveProperties.java
+++ b/src/main/java/com/opentok/ArchiveProperties.java
@@ -100,6 +100,13 @@ public class ArchiveProperties {
             return this;
         }
 
+        /**
+         * Call this method to customize the layout for a composed archive
+         *
+         * @param layout An object of type {@link ArchiveLayout} .
+         *
+         * @return The ArchiveProperties.Builder object with the output mode setting.
+         */
         public Builder layout(ArchiveLayout layout){
             this.layout = layout;
             return this;
@@ -141,6 +148,9 @@ public class ArchiveProperties {
         return outputMode;
     }
 
+    /**
+     * Optionally set a custom layout (composed archives only)
+     */
     public ArchiveLayout layout() {
         return layout;
     }
@@ -166,6 +176,11 @@ public class ArchiveProperties {
         valueList = new ArrayList<String>();
         valueList.add(outputMode.toString());
         params.put("outputMode", valueList);
+
+        valueList = new ArrayList<String>();
+        valueList.add(layout.toString());
+        params.put("layout", valueList);
+
 
         return params;
     }

--- a/src/main/java/com/opentok/ArchiveProperties.java
+++ b/src/main/java/com/opentok/ArchiveProperties.java
@@ -28,12 +28,14 @@ public class ArchiveProperties {
     private boolean hasAudio;
     private boolean hasVideo;
     private OutputMode outputMode;
+    private ArchiveLayout layout;
 
     private ArchiveProperties(Builder builder) {
         this.name = builder.name;
         this.hasAudio = builder.hasAudio;
         this.hasVideo = builder.hasVideo;
         this.outputMode = builder.outputMode;
+        this.layout = builder.layout;
     }
 
     /**
@@ -46,6 +48,7 @@ public class ArchiveProperties {
         private boolean hasAudio = true;
         private boolean hasVideo = true;
         private OutputMode outputMode = OutputMode.COMPOSED;
+        private ArchiveLayout layout = new ArchiveLayout(ArchiveLayout.Type.BESTFIT);
         
 
         /**
@@ -97,6 +100,11 @@ public class ArchiveProperties {
             return this;
         }
 
+        public Builder layout(ArchiveLayout layout){
+            this.layout = layout;
+            return this;
+        }
+
         /**
          * Builds the ArchiveProperties object.
          *
@@ -131,6 +139,10 @@ public class ArchiveProperties {
      */
     public OutputMode outputMode() {
         return outputMode;
+    }
+
+    public ArchiveLayout layout() {
+        return layout;
     }
 
     /**

--- a/src/main/java/com/opentok/Session.java
+++ b/src/main/java/com/opentok/Session.java
@@ -14,6 +14,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import com.opentok.exception.InvalidArgumentException;
 import com.opentok.util.Crypto;
@@ -129,6 +130,10 @@ public class Session {
         dataStringBuilder.append(nonce);
         dataStringBuilder.append("&role=");
         dataStringBuilder.append(role);
+        dataStringBuilder.append("&initial_layout_class_list=");
+        if(tokenOptions.getInitialLayoutClassList() != null ){
+            dataStringBuilder.append(tokenOptions.getInitialLayoutClassList().stream().collect(Collectors.joining(" ")));
+        }
 
         double now = System.currentTimeMillis() / 1000L;
         if (expireTime == 0) {

--- a/src/main/java/com/opentok/Session.java
+++ b/src/main/java/com/opentok/Session.java
@@ -130,8 +130,8 @@ public class Session {
         dataStringBuilder.append(nonce);
         dataStringBuilder.append("&role=");
         dataStringBuilder.append(role);
-        dataStringBuilder.append("&initial_layout_class_list=");
         if(tokenOptions.getInitialLayoutClassList() != null ){
+            dataStringBuilder.append("&initial_layout_class_list=");
             dataStringBuilder.append(tokenOptions.getInitialLayoutClassList().stream().collect(Collectors.joining(" ")));
         }
 

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -186,7 +186,9 @@ public class HttpClient extends DefaultAsyncHttpClient {
         requestJson.put("hasVideo", properties.hasVideo());
         requestJson.put("hasAudio", properties.hasAudio());
         requestJson.put("outputMode", properties.outputMode().toString());
-
+        ObjectNode layout = requestJson.putObject("layout");
+        layout.put("type", properties.layout().getType().toString());
+        layout.put("stylesheet", properties.layout().getStylesheet());
         if (properties.name() != null) {
             requestJson.put("name", properties.name());
         }

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -186,9 +186,11 @@ public class HttpClient extends DefaultAsyncHttpClient {
         requestJson.put("hasVideo", properties.hasVideo());
         requestJson.put("hasAudio", properties.hasAudio());
         requestJson.put("outputMode", properties.outputMode().toString());
-        ObjectNode layout = requestJson.putObject("layout");
-        layout.put("type", properties.layout().getType().toString());
-        layout.put("stylesheet", properties.layout().getStylesheet());
+        if(properties.layout() != null) {
+            ObjectNode layout = requestJson.putObject("layout");
+            layout.put("type", properties.layout().getType().toString());
+            layout.put("stylesheet", properties.layout().getStylesheet());
+        }
         if (properties.name() != null) {
             requestJson.put("name", properties.name());
         }

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -11,17 +11,8 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.opentok.Archive;
+import com.opentok.*;
 import com.opentok.Archive.OutputMode;
-import com.opentok.ArchiveList;
-import com.opentok.ArchiveMode;
-import com.opentok.ArchiveProperties;
-import com.opentok.MediaMode;
-import com.opentok.OpenTok;
-import com.opentok.Role;
-import com.opentok.Session;
-import com.opentok.SessionProperties;
-import com.opentok.TokenOptions;
 import com.opentok.exception.InvalidArgumentException;
 import com.opentok.exception.OpenTokException;
 import org.apache.commons.lang.StringUtils;
@@ -38,6 +29,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -260,7 +252,28 @@ public class OpenTokTest {
     }
 
     @Test
-    public void testTokenRoles() throws
+    public void testTokenLayoutClass() throws
+            OpenTokException, UnsupportedEncodingException, NoSuchAlgorithmException,
+            SignatureException, InvalidKeyException {
+
+        int apiKey = 123456;
+        String apiSecret = "1234567890abcdef1234567890abcdef1234567890";
+        OpenTok opentok = new OpenTok(apiKey, apiSecret);
+        String sessionId = "1_MX4xMjM0NTZ-flNhdCBNYXIgMTUgMTQ6NDI6MjMgUERUIDIwMTR-MC40OTAxMzAyNX4";
+
+        String token = sdk.generateToken(sessionId, new TokenOptions.Builder()
+                .initialLayoutClassList(Arrays.asList("full", "focus"))
+                .build());
+
+        assertNotNull(token);
+        assertTrue(Helpers.verifyTokenSignature(token, apiSecret));
+
+        Map<String, String> tokenData = Helpers.decodeToken(token);
+        assertEquals("full focus", tokenData.get("initial_layout_class_list"));
+    }
+
+    @Test
+    public void testToken() throws
             OpenTokException, UnsupportedEncodingException, NoSuchAlgorithmException,
             SignatureException, InvalidKeyException {
 
@@ -686,6 +699,46 @@ public class OpenTokTest {
                                 "        }")));
         ArchiveProperties properties = new ArchiveProperties.Builder()
                 .outputMode(OutputMode.COMPOSED)
+                .build();
+
+        Archive archive = sdk.startArchive(sessionId, properties);
+        assertNotNull(archive);
+        assertEquals(sessionId, archive.getSessionId());
+        assertNotNull(archive.getId());
+        assertEquals(OutputMode.COMPOSED, archive.getOutputMode());
+
+        verify(postRequestedFor(urlMatching(archivePath)));
+                // TODO: find a way to match JSON without caring about spacing
+                //.withRequestBody(matching(".*"+".*"))
+        assertTrue(Helpers.verifyTokenAuth(apiKey, apiSecret,
+                findAll(postRequestedFor(urlMatching(archivePath)))));
+        Helpers.verifyUserAgent();
+    }
+
+    @Test
+    public void testStartComposedArchiveWithLayout() throws OpenTokException {
+        String sessionId = "SESSIONID";
+
+        stubFor(post(urlEqualTo(archivePath))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\n" +
+                                "          \"createdAt\" : 1395183243556,\n" +
+                                "          \"duration\" : 0,\n" +
+                                "          \"id\" : \"30b3ebf1-ba36-4f5b-8def-6f70d9986fe9\",\n" +
+                                "          \"name\" : \"\",\n" +
+                                "          \"partnerId\" : 123456,\n" +
+                                "          \"reason\" : \"\",\n" +
+                                "          \"sessionId\" : \"SESSIONID\",\n" +
+                                "          \"size\" : 0,\n" +
+                                "          \"status\" : \"started\",\n" +
+                                "          \"url\" : null,\n" +
+                                "          \"outputMode\" : \"composed\"\n" +
+                                "        }")));
+        ArchiveProperties properties = new ArchiveProperties.Builder()
+                .outputMode(OutputMode.COMPOSED)
+                .layout(new ArchiveLayout(ArchiveLayout.Type.CUSTOM, "stream { position: absolute; }"))
                 .build();
 
         Archive archive = sdk.startArchive(sessionId, properties);

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -273,7 +273,7 @@ public class OpenTokTest {
     }
 
     @Test
-    public void testToken() throws
+    public void testTokenRoles() throws
             OpenTokException, UnsupportedEncodingException, NoSuchAlgorithmException,
             SignatureException, InvalidKeyException {
 


### PR DESCRIPTION
Hello. This implements support for [controlling layouts](https://tokbox.com/developer/guides/archiving/layout-control.html)  in composed archives in the start-archive call. 

Addresses issue #131 

I look forward to any feedback you have on this. Thanks!