### PR TITLE
Archive properties resolution property support added

### DIFF
--- a/src/main/java/com/opentok/Archive.java
+++ b/src/main/java/com/opentok/Archive.java
@@ -102,7 +102,7 @@ public class Archive {
     @JsonProperty private boolean hasAudio = true;
     @JsonProperty private OutputMode outputMode = OutputMode.COMPOSED;
     @JsonProperty private String password;
-    @JsonProperty private  String resolution;
+    @JsonProperty private String resolution;
 
     protected Archive() {
     }

--- a/src/main/java/com/opentok/Archive.java
+++ b/src/main/java/com/opentok/Archive.java
@@ -102,6 +102,7 @@ public class Archive {
     @JsonProperty private boolean hasAudio = true;
     @JsonProperty private OutputMode outputMode = OutputMode.COMPOSED;
     @JsonProperty private String password;
+    @JsonProperty private  String resolution;
 
     protected Archive() {
     }
@@ -137,6 +138,13 @@ public class Archive {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * The name of the archive.
+     */
+    public String getResolution() {
+        return resolution;
     }
 
     /**

--- a/src/main/java/com/opentok/ArchiveProperties.java
+++ b/src/main/java/com/opentok/ArchiveProperties.java
@@ -183,12 +183,12 @@ public class ArchiveProperties {
      */
     public Map<String, Collection<String>> toMap() {
         Map<String, Collection<String>> params = new HashMap<String, Collection<String>>();
-        if (null != name) {
+        if (name != null) {
             ArrayList<String> valueList = new ArrayList<String>();
             valueList.add(name);
             params.put("name", valueList);
         }
-        if (null != resolution) {
+        if (resolution != null) {
             ArrayList<String> valueList = new ArrayList<String>();
             valueList.add(resolution);
             params.put("resolution", valueList);

--- a/src/main/java/com/opentok/ArchiveProperties.java
+++ b/src/main/java/com/opentok/ArchiveProperties.java
@@ -25,6 +25,7 @@ public class ArchiveProperties {
 
 
     private String name = null;
+    private String resolution = null;
     private boolean hasAudio;
     private boolean hasVideo;
     private OutputMode outputMode;
@@ -32,6 +33,7 @@ public class ArchiveProperties {
 
     private ArchiveProperties(Builder builder) {
         this.name = builder.name;
+        this.resolution = builder.resolution;
         this.hasAudio = builder.hasAudio;
         this.hasVideo = builder.hasVideo;
         this.outputMode = builder.outputMode;
@@ -45,6 +47,7 @@ public class ArchiveProperties {
      */
     public static class Builder {
         private String name = null;
+        private String resolution = null;
         private boolean hasAudio = true;
         private boolean hasVideo = true;
         private OutputMode outputMode = OutputMode.COMPOSED;
@@ -63,7 +66,21 @@ public class ArchiveProperties {
             this.name = name;
             return this;
         }
-        
+
+        /**
+         * Call this method to set a name to the archive.
+         *
+         * @param resolution The resolution of the archive, either "640x480" (SD, the default) or "1280x720" (HD).
+         * This property only applies to composed archives.
+         * If you set this property and set the outputMode property to "individual", the call in the API method results in an error.
+         *
+         * @return The ArchiveProperties.Builder object with the name setting.
+         */
+        public Builder resolution(String resolution) {
+            this.resolution = resolution;
+            return this;
+        }
+
         /**
          * Call this method to include an audio track (<code>true</code>) or not <code>false</code>).
          *
@@ -128,6 +145,12 @@ public class ArchiveProperties {
         return name;
     }
     /**
+     * Returns the resolution of the archive
+     */
+    public String resolution() {
+        return resolution;
+    }
+    /**
      * Whether the archive has a video track (<code>true</code>) or not (<code>false</code>).
      */
     public boolean hasVideo() {
@@ -164,6 +187,11 @@ public class ArchiveProperties {
             ArrayList<String> valueList = new ArrayList<String>();
             valueList.add(name);
             params.put("name", valueList);
+        }
+        if (null != resolution) {
+            ArrayList<String> valueList = new ArrayList<String>();
+            valueList.add(resolution);
+            params.put("resolution", valueList);
         }
         ArrayList<String> valueList = new ArrayList<String>();
         valueList.add(Boolean.toString(hasAudio));

--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -417,6 +417,10 @@ public class OpenTok {
         if (sessionId == null || sessionId == "") {
             throw new InvalidArgumentException("Session not valid");
         }
+        Boolean hasResolution =  properties != null && properties.resolution() != null && !properties.resolution().isEmpty();
+        if(properties != null && properties.outputMode().equals(Archive.OutputMode.INDIVIDUAL) && hasResolution) {
+            throw new InvalidArgumentException("Resolution must not be specified in individual output mode.");
+        }
         // TODO: do validation on sessionId and name
         String archive = this.client.startArchive(sessionId, properties);
         try {

--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -419,7 +419,7 @@ public class OpenTok {
         }
         Boolean hasResolution =  properties != null && properties.resolution() != null && !properties.resolution().isEmpty();
         if(properties != null && properties.outputMode().equals(Archive.OutputMode.INDIVIDUAL) && hasResolution) {
-            throw new InvalidArgumentException("Resolution must not be specified in individual output mode.");
+            throw new InvalidArgumentException("The resolution cannot be specified for individual output mode.");
         }
         // TODO: do validation on sessionId and name
         String archive = this.client.startArchive(sessionId, properties);

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -7,20 +7,16 @@
  */
 package com.opentok.util;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.net.SocketAddress;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.opentok.ArchiveProperties;
 import com.opentok.SignalProperties;
+import com.opentok.constants.DefaultApiUrl;
+import com.opentok.constants.Version;
+import com.opentok.exception.OpenTokException;
+import com.opentok.exception.RequestException;
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
@@ -33,15 +29,17 @@ import org.asynchttpclient.filter.FilterException;
 import org.asynchttpclient.filter.RequestFilter;
 import org.asynchttpclient.proxy.ProxyServer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.opentok.ArchiveProperties;
-import com.opentok.constants.DefaultApiUrl;
-import com.opentok.constants.Version;
-import com.opentok.exception.OpenTokException;
-import com.opentok.exception.RequestException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 public class HttpClient extends DefaultAsyncHttpClient {
     
@@ -240,6 +238,9 @@ public class HttpClient extends DefaultAsyncHttpClient {
         if (properties.name() != null) {
             requestJson.put("name", properties.name());
         }
+        if (properties.resolution() != null) {
+            requestJson.put("resolution", properties.resolution());
+        }
         try {
             requestBody = new ObjectMapper().writeValueAsString(requestJson);
         } catch (JsonProcessingException e) {
@@ -256,6 +257,8 @@ public class HttpClient extends DefaultAsyncHttpClient {
                 case 200:
                     responseString = response.getResponseBody();
                     break;
+                case 400:
+                    throw new RequestException("Could not start an OpenTok Archive. A bad request, check input archive properties like resolution etc.");
                 case 403:
                     throw new RequestException("Could not start an OpenTok Archive. The request was not authorized.");
                 case 404:

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -773,7 +773,7 @@ public class OpenTokTest {
         try {
             sdk.startArchive(sessionId, properties);
         } catch (InvalidArgumentException e) {
-            assertEquals(e.getMessage(),"Resolution must not be specified in individual output mode.");
+            assertEquals(e.getMessage(),"The resolution cannot be specified for individual output mode.");
         }
     }
 

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -736,6 +736,47 @@ public class OpenTokTest {
     }
 
     @Test
+    public void testStartArchiveWithResolution() throws OpenTokException {
+        boolean exceptionThrown = false;
+        String sessionId = "SESSIONID";
+        ArchiveProperties properties = new ArchiveProperties.Builder().resolution("1280x720").build();
+
+        stubFor(post(urlEqualTo(archivePath))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\n" +
+                                "          \"createdAt\" : 1395183243556,\n" +
+                                "          \"duration\" : 0,\n" +
+                                "          \"id\" : \"30b3ebf1-ba36-4f5b-8def-6f70d9986fe9\",\n" +
+                                "          \"name\" : \"\",\n" +
+                                "          \"resolution\" : \"1280x720\",\n" +
+                                "          \"partnerId\" : 123456,\n" +
+                                "          \"reason\" : \"\",\n" +
+                                "          \"sessionId\" : \"SESSIONID\",\n" +
+                                "          \"size\" : 0,\n" +
+                                "          \"status\" : \"started\",\n" +
+                                "          \"url\" : null\n" +
+                                "        }")));
+        try {
+            Archive archive = sdk.startArchive(sessionId, properties);
+            assertNotNull(archive);
+            assertEquals(sessionId, archive.getSessionId());
+            assertNotNull(archive.getId());
+            assertEquals(archive.getResolution(),"1280x720");
+            verify(postRequestedFor(urlMatching(archivePath)));
+            // TODO: find a way to match JSON without caring about spacing
+            //.withRequestBody(matching(".*"+".*"))
+            assertTrue(Helpers.verifyTokenAuth(apiKey, apiSecret,
+                    findAll(postRequestedFor(urlMatching(archivePath)))));
+            Helpers.verifyUserAgent();
+        } catch (OpenTokException e) {
+            exceptionThrown = true;
+        }
+        assertFalse(exceptionThrown);
+    }
+
+    @Test
     public void testStartArchiveWithName() throws OpenTokException {
         String sessionId = "SESSIONID";
         String name = "archive_name";

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -767,6 +767,17 @@ public class OpenTokTest {
     }
 
     @Test
+    public void testStartArchiveWithResolutionInIndividualMode() throws OpenTokException {
+        String sessionId = "SESSIONID";
+        ArchiveProperties properties = new ArchiveProperties.Builder().outputMode(OutputMode.INDIVIDUAL).resolution("1280x720").build();
+        try {
+            sdk.startArchive(sessionId, properties);
+        } catch (InvalidArgumentException e) {
+            assertEquals(e.getMessage(),"Resolution must not be specified in individual output mode.");
+        }
+    }
+
+    @Test
     public void testStartArchiveWithName() throws OpenTokException {
         String sessionId = "SESSIONID";
         String name = "archive_name";

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -737,10 +737,8 @@ public class OpenTokTest {
 
     @Test
     public void testStartArchiveWithResolution() throws OpenTokException {
-        boolean exceptionThrown = false;
         String sessionId = "SESSIONID";
         ArchiveProperties properties = new ArchiveProperties.Builder().resolution("1280x720").build();
-
         stubFor(post(urlEqualTo(archivePath))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -758,22 +756,14 @@ public class OpenTokTest {
                                 "          \"status\" : \"started\",\n" +
                                 "          \"url\" : null\n" +
                                 "        }")));
-        try {
-            Archive archive = sdk.startArchive(sessionId, properties);
-            assertNotNull(archive);
-            assertEquals(sessionId, archive.getSessionId());
-            assertNotNull(archive.getId());
-            assertEquals(archive.getResolution(),"1280x720");
-            verify(postRequestedFor(urlMatching(archivePath)));
-            // TODO: find a way to match JSON without caring about spacing
-            //.withRequestBody(matching(".*"+".*"))
-            assertTrue(Helpers.verifyTokenAuth(apiKey, apiSecret,
-                    findAll(postRequestedFor(urlMatching(archivePath)))));
-            Helpers.verifyUserAgent();
-        } catch (OpenTokException e) {
-            exceptionThrown = true;
-        }
-        assertFalse(exceptionThrown);
+        Archive archive = sdk.startArchive(sessionId, properties);
+        assertNotNull(archive);
+        assertEquals(sessionId, archive.getSessionId());
+        assertEquals(archive.getResolution(),"1280x720");
+        verify(postRequestedFor(urlMatching(archivePath)));
+        assertTrue(Helpers.verifyTokenAuth(apiKey, apiSecret,
+                findAll(postRequestedFor(urlMatching(archivePath)))));
+        Helpers.verifyUserAgent();
     }
 
     @Test


### PR DESCRIPTION
Something like
```Java
ArchiveProperties properties = new ArchiveProperties.Builder().resolution("1280x720").build();
```
and  exception like
```Java
 throw new RequestException("Could not start an OpenTok Archive. A bad request, check input archive properties like resolution etc.");
```
added.
