### PR TITLE
Updated licensing since the year changed

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2018 TokBox, Inc.
+Copyright (c) 2014-2021 Vonage.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.gradle
+++ b/build.gradle
@@ -112,13 +112,13 @@ uploadArchives {
                         id 'manasdpradhan'
                         name 'Manas Pradhan'
                         email 'manas@tokbox.com'
-                        organization 'TokBox, Inc.'
+                        organization 'Vonage.'
                     }
                     developer {
                         id 'aoberoi'
                         name 'Ankur Oberoi'
                         email 'aoberoi@gmail.com'
-                        organization 'TokBox, Inc.'
+                        organization 'Vonage.'
                     }
                 }
             }

--- a/codequality/HEADER
+++ b/codequality/HEADER
@@ -1,5 +1,5 @@
 OpenTok Java SDK
-Copyright (C) ${year} TokBox, Inc.
+Copyright (C) ${year} Vonage.
 http://www.tokbox.com
 
 Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/Archive.java
+++ b/src/main/java/com/opentok/Archive.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/ArchiveLayout.java
+++ b/src/main/java/com/opentok/ArchiveLayout.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/ArchiveList.java
+++ b/src/main/java/com/opentok/ArchiveList.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/ArchiveMode.java
+++ b/src/main/java/com/opentok/ArchiveMode.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/ArchiveProperties.java
+++ b/src/main/java/com/opentok/ArchiveProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/Broadcast.java
+++ b/src/main/java/com/opentok/Broadcast.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/BroadcastLayout.java
+++ b/src/main/java/com/opentok/BroadcastLayout.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/BroadcastProperties.java
+++ b/src/main/java/com/opentok/BroadcastProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/CreatedSession.java
+++ b/src/main/java/com/opentok/CreatedSession.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/MediaMode.java
+++ b/src/main/java/com/opentok/MediaMode.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/Role.java
+++ b/src/main/java/com/opentok/Role.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/Rtmp.java
+++ b/src/main/java/com/opentok/Rtmp.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/RtmpProperties.java
+++ b/src/main/java/com/opentok/RtmpProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/Session.java
+++ b/src/main/java/com/opentok/Session.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/SessionProperties.java
+++ b/src/main/java/com/opentok/SessionProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/SignalProperties.java
+++ b/src/main/java/com/opentok/SignalProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/Sip.java
+++ b/src/main/java/com/opentok/Sip.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/SipProperties.java
+++ b/src/main/java/com/opentok/SipProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/Stream.java
+++ b/src/main/java/com/opentok/Stream.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/StreamList.java
+++ b/src/main/java/com/opentok/StreamList.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/StreamListProperties.java
+++ b/src/main/java/com/opentok/StreamListProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/StreamProperties.java
+++ b/src/main/java/com/opentok/StreamProperties.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/TokenOptions.java
+++ b/src/main/java/com/opentok/TokenOptions.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/constants/DefaultApiUrl.java
+++ b/src/main/java/com/opentok/constants/DefaultApiUrl.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/constants/Version.java
+++ b/src/main/java/com/opentok/constants/Version.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/constants/package-info.java
+++ b/src/main/java/com/opentok/constants/package-info.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/exception/InvalidArgumentException.java
+++ b/src/main/java/com/opentok/exception/InvalidArgumentException.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/exception/OpenTokException.java
+++ b/src/main/java/com/opentok/exception/OpenTokException.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/exception/RequestException.java
+++ b/src/main/java/com/opentok/exception/RequestException.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/exception/package-info.java
+++ b/src/main/java/com/opentok/exception/package-info.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/package-info.java
+++ b/src/main/java/com/opentok/package-info.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/util/Crypto.java
+++ b/src/main/java/com/opentok/util/Crypto.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/main/java/com/opentok/util/TokenGenerator.java
+++ b/src/main/java/com/opentok/util/TokenGenerator.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/test/java/com/opentok/test/Helpers.java
+++ b/src/test/java/com/opentok/test/Helpers.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -1,6 +1,6 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2020 TokBox, Inc.
+ * Copyright (C) 2021 Vonage.
  * http://www.tokbox.com
  *
  * Licensed under The MIT License (MIT). See LICENSE file for more information.


### PR DESCRIPTION
Updates the copyright year in the header to 2021, and also changes the entity name from "TokBox, Inc" to "Vonage" per the legal department (TokBox, Inc is no longer an entity).

We need this updated before any bugfixes can be done for the year, as the code linters check this.