### PR TITLE
Bumped version and made bumping more robust

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -8,6 +8,4 @@ serialize =
 
 [bumpversion:file:build.gradle]
 
-[bumpversion:file:README.md]
-
 [bumpversion:file:src/main/java/com/opentok/constants/Version.java]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When you use Maven as your build tool, you can manage dependencies in the `pom.x
 <dependency>
     <groupId>com.tokbox</groupId>
     <artifactId>opentok-server-sdk</artifactId>
-    <version>4.4.0</version>
+    <version>[4.4.1,5.0)</version>
 </dependency>
 ```
 
@@ -41,7 +41,7 @@ When you use Gradle as your build tool, you can manage dependencies in the `buil
 
 ```groovy
 dependencies {
-  compile group: 'com.tokbox', name: 'opentok-server-sdk', version: '4.4.0'
+  compile group: 'com.tokbox', name: 'opentok-server-sdk', version: '[4.4.1,5.0)'
 }
 ```
 

--- a/src/main/java/com/opentok/constants/Version.java
+++ b/src/main/java/com/opentok/constants/Version.java
@@ -8,5 +8,5 @@
 package com.opentok.constants;
 
 public class Version {
-    public static final String VERSION = "4.4.0";
+    public static final String VERSION = "4.4.1";
 }


### PR DESCRIPTION
Finished the version bump to 4.4.1 for the release.

Also changed the README so that it shows using a range by default so we don't have customer hard-coded to patch releases. 