### PR TITLE
Fix Maven publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,4 +44,4 @@ jobs:
           signingPassword: ${{secrets.SIGNING_PASSWORD}}
           OSS_USERNAME: ${{secrets.OSS_USERNAME}}
           OSS_PASSWORD: ${{secrets.OSS_PASSWORD}}
-        run: OSS_USERNAME=$OSS_USERNAME OSS_PASSWORD=$OSS_PASSWORD signingKey=$signingKey signingPassword=$signingPassword gradle publish --info
+        run: OSS_USERNAME=$OSS_USERNAME OSS_PASSWORD=$OSS_PASSWORD signingKey=$signingKey signingPassword=$signingPassword gradle publishMavenJavaPublicationToMavenRepository --info

--- a/build.gradle
+++ b/build.gradle
@@ -150,8 +150,5 @@ publishing {
 }
 
 signing {
-    def signingKey = System.getenv("signingKey")
-    def signingPassword = System.getenv("signingPassword")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
+    sign configurations.archives
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.time.LocalDate
+
 plugins {
     id 'java-library'
     id 'jacoco'
@@ -25,7 +27,7 @@ dependencies {
     implementation 'org.asynchttpclient:async-http-client:2.12.3'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'commons-codec:commons-codec:1.15'
-    implementation 'org.bitbucket.b_c:jose4j:0.7.11'
+    implementation 'org.bitbucket.b_c:jose4j:0.7.12'
 }
 
 task sourcesJar(type: Jar) {
@@ -62,18 +64,19 @@ jacocoTestReport {
 }
 check.dependsOn jacocoTestReport
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 license {
     header rootProject.file('codequality/HEADER')
-    ext.year = Calendar.getInstance().get(Calendar.YEAR)
+    ext.year = LocalDate.now().getYear()
 }
 
 artifacts {
     archives javadocJar, sourcesJar
 }
-
-ext.isReleaseVersion = hasProperty('isReleaseVersion') ? isReleaseVersion : false
-ext.ossrhUsername = hasProperty('ossrhUsername') ? ossrhUsername : 'dummyuser'
-ext.ossrhPassword = hasProperty('ossrhPassword') ? ossrhPassword : 'dummypass'
 
 publishing {
     publications {
@@ -116,7 +119,7 @@ publishing {
                         organization = 'Vonage'
                     }
                     developer {
-                        id = 'SMadani'
+                        id = 'smadani'
                         name = 'Sina Madani'
                         email = 'sina.madani@vonage.com'
                         organization = 'Vonage'

--- a/publish.sh
+++ b/publish.sh
@@ -2,7 +2,7 @@
 
 . ./secret.sh
 
-./gradlew uploadArchives \
+./gradlew clean publish --info --build-cache \
   -PisReleaseVersion=1 \
   -Psigning.keyId="${GPG_KEYID}" \
   -Psigning.password="${GPG_PASSWORD}" \


### PR DESCRIPTION
Turns out that the signing keys are invalid / were never used which prevented the GitHub workflow from publishing to Maven Central. This PR fixes that.