### PR TITLE
Add end-to-end encryption support

### DIFF
--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -243,7 +243,7 @@ public class OpenTok {
      */
     public Session createSession(SessionProperties properties) throws OpenTokException {
         final SessionProperties _properties = properties != null ? properties : new SessionProperties.Builder().build();
-        final Map<String, Collection<String>> params = _properties.toMap();
+        final Map<String, List<String>> params = _properties.toMap();
         final String response = client.createSession(params);
 
         try {

--- a/src/main/java/com/opentok/Session.java
+++ b/src/main/java/com/opentok/Session.java
@@ -27,17 +27,13 @@ import org.apache.commons.codec.binary.Base64;
 * to get the session ID.
 */
 public class Session {
-
     private String sessionId;
     private int apiKey;
     private String apiSecret;
     private SessionProperties properties;
     
     protected Session(String sessionId, int apiKey, String apiSecret) {
-        this.sessionId = sessionId;
-        this.apiKey = apiKey;
-        this.apiSecret = apiSecret;
-        this.properties = new SessionProperties.Builder().build();
+        this(sessionId, apiKey, apiSecret, new SessionProperties.Builder().build());
     }
     
     protected Session(String sessionId, int apiKey, String apiSecret, SessionProperties properties) {
@@ -83,7 +79,6 @@ public class Session {
      * @see #generateToken(TokenOptions tokenOptions)
      */
     public String generateToken() throws OpenTokException {
-        // NOTE: maybe there should be a static object for the defaultTokenOptions?
         return this.generateToken(new TokenOptions.Builder().build());
     }
 

--- a/src/main/java/com/opentok/SessionProperties.java
+++ b/src/main/java/com/opentok/SessionProperties.java
@@ -213,9 +213,11 @@ public class SessionProperties {
         archiveModeValueList.add(archiveMode.toString());
         params.put("archiveMode", archiveModeValueList);
 
-        ArrayList<String> e2eeValueList = new ArrayList<>(1);
-        e2eeValueList.add(""+e2ee);
-        params.put("e2ee", e2eeValueList);
+        if (e2ee) {
+            ArrayList<String> e2eeValueList = new ArrayList<>(1);
+            e2eeValueList.add("" + e2ee);
+            params.put("e2ee", e2eeValueList);
+        }
 
         return params;
     }

--- a/src/main/java/com/opentok/SessionProperties.java
+++ b/src/main/java/com/opentok/SessionProperties.java
@@ -122,6 +122,8 @@ public class SessionProperties {
          * from client to client. Media is already encrypted P2P, client to client, through WebRTC protocols
          * when using a relayed session. This feature adds an encryption layer by encrypting the media payload at the
          * client so that it will remain encrypted through the media server when routing media to other clients.
+         * Therefore, you must also set {@link #mediaMode(MediaMode)} to {@linkplain MediaMode#ROUTED} when
+         * calling this method.
          *
          * @return The SessionProperties.Builder object with the e2ee property set to {@code true}.
          */
@@ -136,10 +138,21 @@ public class SessionProperties {
          * @return The SessionProperties object.
          */
         public SessionProperties build() {
-            // Would throw in this case, but would introduce a backwards incompatible change.
-            //if (this.archiveMode == ArchiveMode.ALWAYS && this.mediaMode != MediaMode.ROUTED) {
-            //    throw new InvalidArgumentException("A session with always archive mode must also have the routed media mode.");
-            //}
+            if (this.archiveMode == ArchiveMode.ALWAYS && this.mediaMode != MediaMode.ROUTED) {
+                throw new IllegalStateException(
+                    "A session with ALWAYS archive mode must also have the ROUTED media mode."
+                );
+            }
+            if (e2ee && mediaMode != MediaMode.ROUTED) {
+                throw new IllegalStateException(
+                    "A session with RELAYED media mode cannot have end-to-end encryption enabled."
+                );
+            }
+            if (e2ee && archiveMode == ArchiveMode.ALWAYS) {
+                throw new IllegalStateException(
+                    "A session with ALWAYS archive mode cannot have end-to-end encryption enabled."
+                );
+            }
             return new SessionProperties(this);
         }
     }

--- a/src/main/java/com/opentok/SessionProperties.java
+++ b/src/main/java/com/opentok/SessionProperties.java
@@ -118,11 +118,8 @@ public class SessionProperties {
         }
 
         /**
-         * End-to-end encryption (or E2EE) allows application developers to encrypt media in routed sessions
-         * from client to client. Media is already encrypted P2P, client to client, through WebRTC protocols
-         * when using a relayed session. This feature adds an encryption layer by encrypting the media payload at the
-         * client so that it will remain encrypted through the media server when routing media to other clients.
-         * Therefore, you must also set {@link #mediaMode(MediaMode)} to {@linkplain MediaMode#ROUTED} when
+         * Enables <a href="https://tokbox.com/developer/guides/end-to-end-encryption">end-to-end encryption</a> for a routed session.
+         * You must also set {@link #mediaMode(MediaMode)} to {@linkplain MediaMode#ROUTED} when
          * calling this method.
          *
          * @return The SessionProperties.Builder object with the e2ee property set to {@code true}.

--- a/src/main/java/com/opentok/SessionProperties.java
+++ b/src/main/java/com/opentok/SessionProperties.java
@@ -180,10 +180,10 @@ public class SessionProperties {
     }
 
     /**
-     * End-to-end encryption (or E2EE) allows application developers to encrypt media in routed sessions from client
-     * to client. Media is already encrypted P2P, client to client, through WebRTC protocols when using a relayed
-     * session. This feature adds an encryption layer by encrypting the media payload at the client so that it will
-     * remain encrypted through the media server when routing media to other clients.
+     * Defines whether the session will use
+     * <a href="https://tokbox.com/developer/guides/end-to-end-encryption">end-to-end encryption</a>.
+     * See {@link com.opentok.SessionProperties.Builder#endToEndEncryption()}.
+     * 
      *
      * @return {@code true} if end-to-end encryption is enabled, {@code false} otherwise.
      */

--- a/src/main/java/com/opentok/SessionProperties.java
+++ b/src/main/java/com/opentok/SessionProperties.java
@@ -10,10 +10,7 @@ package com.opentok;
 import com.opentok.exception.InvalidArgumentException;
 import org.apache.commons.validator.routines.InetAddressValidator;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 
 /**
@@ -23,16 +20,16 @@ import java.util.Map;
  * @see OpenTok#createSession(com.opentok.SessionProperties properties)
  */
 public class SessionProperties {
-
-
     private String location;
     private MediaMode mediaMode;
     private ArchiveMode archiveMode;
+    private boolean e2ee;
 
     private SessionProperties(Builder builder) {
         this.location = builder.location;
         this.mediaMode = builder.mediaMode;
         this.archiveMode = builder.archiveMode;
+        this.e2ee = builder.e2ee;
     }
 
     /**
@@ -41,10 +38,10 @@ public class SessionProperties {
      * @see SessionProperties
      */
     public static class Builder {
-        private String location = null;
+        private String location;
         private MediaMode mediaMode = MediaMode.RELAYED;
         private ArchiveMode archiveMode = ArchiveMode.MANUAL;
-        
+        private boolean e2ee = false;
 
         /**
          * Call this method to set an IP address that the OpenTok servers will use to
@@ -108,7 +105,7 @@ public class SessionProperties {
         /**
          * Call this method to determine whether the session will be automatically archived (<code>ArchiveMode.ALWAYS</code>)
          * or not (<code>ArchiveMode.MANUAL</code>).
-         *
+         * <p>
          * Using an always archived session also requires the routed media mode (<code>MediaMode.ROUTED</code>).
          *
          * @param archiveMode The Archive mode.
@@ -117,6 +114,19 @@ public class SessionProperties {
          */
         public Builder archiveMode(ArchiveMode archiveMode) {
             this.archiveMode = archiveMode;
+            return this;
+        }
+
+        /**
+         * End-to-end encryption (or E2EE) allows application developers to encrypt media in routed sessions
+         * from client to client. Media is already encrypted P2P, client to client, through WebRTC protocols
+         * when using a relayed session. This feature adds an encryption layer by encrypting the media payload at the
+         * client so that it will remain encrypted through the media server when routing media to other clients.
+         *
+         * @return The SessionProperties.Builder object with the e2ee property set to {@code true}.
+         */
+        public Builder endToEndEncryption() {
+            this.e2ee = true;
             return this;
         }
 
@@ -133,6 +143,7 @@ public class SessionProperties {
             return new SessionProperties(this);
         }
     }
+
     /**
     * The location hint IP address. See {@link SessionProperties.Builder#location(String location)}.
     */
@@ -159,23 +170,39 @@ public class SessionProperties {
     }
 
     /**
+     * End-to-end encryption (or E2EE) allows application developers to encrypt media in routed sessions from client
+     * to client. Media is already encrypted P2P, client to client, through WebRTC protocols when using a relayed
+     * session. This feature adds an encryption layer by encrypting the media payload at the client so that it will
+     * remain encrypted through the media server when routing media to other clients.
+     *
+     * @return {@code true} if end-to-end encryption is enabled, {@code false} otherwise.
+     */
+    public boolean isEndToEndEncrypted() {
+        return e2ee;
+    }
+
+    /**
      * Returns the session properties as a Map.
      */
-    public Map<String, Collection<String>> toMap() {
-        Map<String, Collection<String>> params = new HashMap<>();
+    public Map<String, List<String>> toMap() {
+        Map<String, List<String>> params = new HashMap<>();
         if (null != location) {
-            ArrayList<String> valueList = new ArrayList<>();
+            ArrayList<String> valueList = new ArrayList<>(1);
             valueList.add(location);
             params.put("location", valueList);
         }
 
-        ArrayList<String> mediaModeValueList = new ArrayList<>();
+        ArrayList<String> mediaModeValueList = new ArrayList<>(1);
         mediaModeValueList.add(mediaMode.toString());
         params.put("p2p.preference", mediaModeValueList);
 
-        ArrayList<String> archiveModeValueList = new ArrayList<>();
+        ArrayList<String> archiveModeValueList = new ArrayList<>(1);
         archiveModeValueList.add(archiveMode.toString());
         params.put("archiveMode", archiveModeValueList);
+
+        ArrayList<String> e2eeValueList = new ArrayList<>(1);
+        e2eeValueList.add(""+e2ee);
+        params.put("e2ee", e2eeValueList);
 
         return params;
     }

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -48,17 +48,9 @@ public class HttpClient extends DefaultAsyncHttpClient {
         this.apiUrl = builder.apiUrl;
     }
 
-    public String createSession(Map<String, Collection<String>> params) throws RequestException {
-        Map<String, List<String>> paramsWithList = null;
-        if (params != null) {
-            paramsWithList = new HashMap<>();
-            for (Entry<String, Collection<String>> entry : params.entrySet()) {
-                paramsWithList.put(entry.getKey(), new ArrayList<>(entry.getValue()));
-            }
-        }
-
+    public String createSession(Map<String, List<String>> params) throws RequestException {
         Future<Response> request = this.preparePost(this.apiUrl + "/session/create")
-                .setFormParams(paramsWithList)
+                .setFormParams(params)
                 .setHeader("Accept", "application/json") // XML version is deprecated
                 .execute();
 


### PR DESCRIPTION
This PR adds the `e2ee` option to session creation, along with the validation logic which throws an unchecked exception. See [the E2EE docs](https://tokbox.com/developer/guides/end-to-end-encryption/) for details.