### PR TITLE
Allow User-Agent to be extended

### DIFF
--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.opentok.constants.DefaultUserAgent;
 import com.opentok.exception.InvalidArgumentException;
 import com.opentok.exception.OpenTokException;
 import com.opentok.exception.RequestException;
@@ -63,9 +64,7 @@ public class OpenTok {
      * @param apiSecret Your OpenTok API secret. (See your <a href="https://tokbox.com/account">Vonage Video API account page</a>.)
      */
     public OpenTok(int apiKey, String apiSecret) {
-        this.apiKey = apiKey;
-        this.apiSecret = apiSecret.trim();
-        this.client = new HttpClient.Builder(apiKey, apiSecret).build();
+        this(apiKey, apiSecret, new HttpClient.Builder(apiKey, apiSecret).build());
     }
 
     private OpenTok(int apiKey, String apiSecret, HttpClient httpClient) {
@@ -991,6 +990,7 @@ public class OpenTok {
         private int apiKey;
         private String apiSecret;
         private String apiUrl;
+        private String appendUserAgent;
         private Proxy proxy;
         private ProxyAuthScheme proxyAuthScheme;
         private String principal;
@@ -1046,6 +1046,18 @@ public class OpenTok {
         }
 
         /**
+         * Append a custom string to the client's User-Agent. This is to enable tracking for custom integrations.
+         *
+         * @param appendUserAgent The string to append to the user agent.
+         *
+         * @return This Builder with the additional user agent string.
+         */
+        public Builder appendToUserAgent(String appendUserAgent) {
+            this.appendUserAgent = appendUserAgent;
+            return this;
+        }
+
+        /**
          * Builds the OpenTok object with the settings provided to this
          * Builder object.
          *
@@ -1062,6 +1074,9 @@ public class OpenTok {
             }
             if (requestTimeout != 0) {
                 clientBuilder.requestTimeoutMS(requestTimeout);
+            }
+            if (appendUserAgent != null && !appendUserAgent.trim().isEmpty()) {
+                clientBuilder.userAgent(DefaultUserAgent.DEFAULT_USER_AGENT+" "+appendUserAgent);
             }
 
             return new OpenTok(apiKey, apiSecret, clientBuilder.build());

--- a/src/main/java/com/opentok/constants/DefaultUserAgent.java
+++ b/src/main/java/com/opentok/constants/DefaultUserAgent.java
@@ -1,0 +1,13 @@
+/**
+ * OpenTok Java SDK
+ * Copyright (C) 2023 Vonage.
+ * http://www.tokbox.com
+ *
+ * Licensed under The MIT License (MIT). See LICENSE file for more information.
+ */
+package com.opentok.constants;
+
+public class DefaultUserAgent {
+    public static final String DEFAULT_USER_AGENT =
+        "Opentok-Java-SDK/"+Version.VERSION+" JRE/"+System.getProperty("java.version");
+}

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.opentok.*;
 import com.opentok.constants.DefaultApiUrl;
+import com.opentok.constants.DefaultUserAgent;
 import com.opentok.constants.Version;
 import com.opentok.exception.InvalidArgumentException;
 import com.opentok.exception.OpenTokException;
@@ -38,7 +39,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 public class HttpClient extends DefaultAsyncHttpClient {
-
     private final String apiUrl;
     private final int apiKey;
 
@@ -1303,6 +1303,7 @@ public class HttpClient extends DefaultAsyncHttpClient {
         private String principal;
         private String password;
         private String apiUrl;
+        private String userAgent = DefaultUserAgent.DEFAULT_USER_AGENT;
         private AsyncHttpClientConfig config;
         private int requestTimeoutMS;
 
@@ -1340,18 +1341,29 @@ public class HttpClient extends DefaultAsyncHttpClient {
             return this;
         }
 
+        /**
+         * Sets the user agent to a custom value.
+         *
+         * @param userAgent The user agent.
+         *
+         * @return This Builder with user agent string.
+         */
+        public Builder userAgent(String userAgent) {
+            this.userAgent = userAgent;
+            return this;
+        }
+
         public HttpClient build() {
             DefaultAsyncHttpClientConfig.Builder configBuilder = new DefaultAsyncHttpClientConfig.Builder()
-                    .setUserAgent("Opentok-Java-SDK/" + Version.VERSION + " JRE/" + System.getProperty("java.version"))
+                    .setUserAgent(userAgent)
                     .addRequestFilter(new TokenAuthRequestFilter(apiKey, apiSecret));
+
             if (apiUrl == null) {
                 apiUrl = DefaultApiUrl.DEFAULT_API_URI;
             }
-
             if (proxy != null) {
                 configBuilder.setProxyServer(createProxyServer(proxy, proxyAuthScheme, principal, password));
             }
-
             if (requestTimeoutMS != 0) {
                 configBuilder.setRequestTimeout(requestTimeoutMS);
             }


### PR DESCRIPTION
This PR enables users to append to the User-Agent string, which is useful when building custom integrations for tracking usage. Note that it doesn't allow users to override or replace the default user agent, only append to it.