### PR TITLE
Audio only broadcasts

### DIFF
--- a/src/main/java/com/opentok/Broadcast.java
+++ b/src/main/java/com/opentok/Broadcast.java
@@ -34,14 +34,17 @@ public class Broadcast {
          */
         AUTO,
         /**
-         * Strams will be included in the archive based on calls to the
+         * Streams will be included in the archive based on calls to the
          * {@link OpenTok#addBroadcastStream(String, String, boolean, boolean)} and
          * {@link OpenTok#removeBroadcastStream(String, String)} methods.
          */
         MANUAL;
 
         @JsonValue
-        public String toString() { return super.toString().toLowerCase(); }
+        @Override
+        public String toString() {
+            return name().toLowerCase();
+        }
     }
 
     @JsonProperty private String id;
@@ -52,8 +55,10 @@ public class Broadcast {
     @JsonProperty private String resolution;
     @JsonProperty private String status;
     @JsonProperty private String multiBroadcastTag;
+    @JsonProperty private boolean hasAudio = true;
+    @JsonProperty private boolean hasVideo = true;
     @JsonProperty private StreamMode streamMode = StreamMode.AUTO;
-    private List<Rtmp> rtmpList = new ArrayList<>();
+    private List<Rtmp> rtmpList = new ArrayList<>(5);
     private String hls;
 
     /**
@@ -165,13 +170,18 @@ public class Broadcast {
         return rtmpList;
     }
 
-    @Override
-    public String toString() {
-        try {
-            return new ObjectMapper().writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            return "";
-        }
+    /**
+     * Whether the broadcast has audio (<code>true</code>) or not (<code>false</code>).
+     */
+    public boolean hasAudio() {
+        return hasAudio;
+    }
+
+    /**
+     * Whether the broadcast has video (<code>true</code>) or not (<code>false</code>).
+     */
+    public boolean hasVideo() {
+        return hasVideo;
     }
 
     /**
@@ -182,4 +192,12 @@ public class Broadcast {
         return streamMode;
     }
 
+    @Override
+    public String toString() {
+        try {
+            return new ObjectMapper().writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            return "";
+        }
+    }
 }

--- a/src/main/java/com/opentok/BroadcastProperties.java
+++ b/src/main/java/com/opentok/BroadcastProperties.java
@@ -19,19 +19,23 @@ import java.util.List;
  * {@link OpenTok#startBroadcast(String sessionId, BroadcastProperties properties)} method.
  */
 public class BroadcastProperties {
-    private BroadcastLayout layout;
-    private int maxDuration;
-    private boolean hasHls;
-    private List<RtmpProperties> rtmpList;
-    private String resolution;
-    private String multiBroadcastTag;
-    private StreamMode streamMode;
-    private Hls hls;
+    private final BroadcastLayout layout;
+    private final int maxDuration;
+    private final boolean hasHls;
+    private final boolean hasAudio;
+    private final boolean hasVideo;
+    private final List<RtmpProperties> rtmpList;
+    private final String resolution;
+    private final String multiBroadcastTag;
+    private final StreamMode streamMode;
+    private final Hls hls;
 
     private BroadcastProperties(Builder builder) {
         this.layout = builder.layout;
         this.maxDuration = builder.maxDuration;
         this.hasHls = builder.hasHls;
+        this.hasAudio = builder.hasAudio;
+        this.hasVideo = builder.hasVideo;
         this.hls = builder.hls;
         this.rtmpList = builder.rtmpList;
         this.resolution = builder.resolution;
@@ -48,9 +52,11 @@ public class BroadcastProperties {
         private BroadcastLayout layout = new BroadcastLayout(BroadcastLayout.Type.BESTFIT);
         private int maxDuration = 7200;
         private boolean hasHls = false;
+        private boolean hasAudio = true;
+        private boolean hasVideo = true;
         private String multiBroadcastTag;
         private Hls hls;
-        private List<RtmpProperties> rtmpList = new ArrayList<>();
+        private final List<RtmpProperties> rtmpList = new ArrayList<>(5);
         private String resolution = "640x480";
         private StreamMode streamMode = StreamMode.AUTO;
 
@@ -108,6 +114,30 @@ public class BroadcastProperties {
         }
 
         /**
+         * Whether to include audio in the broadcast ({@code true} by default).
+         *
+         * @param hasAudio {@code true} if audio should be included, {@code false} otherwise.
+         *
+         * @return The BroadcastProperties.Builder object with the hasAudio setting.
+         */
+        public Builder hasAudio(boolean hasAudio) {
+            this.hasAudio = hasAudio;
+            return this;
+        }
+
+        /**
+         * Whether to include video in the broadcast ({@code true} by default).
+         *
+         * @param hasVideo {@code true} if video should be included, {@code false} otherwise.
+         *
+         * @return The BroadcastProperties.Builder object with the hasVideo setting.
+         */
+        public Builder hasVideo(boolean hasVideo) {
+            this.hasVideo = hasVideo;
+            return this;
+        }
+
+        /**
          * Call this method to set a list of RTMP broadcast streams. There is a limit of
          * 5 RTMP streams.
          *
@@ -115,7 +145,7 @@ public class BroadcastProperties {
          *
          * @return The BroadcastProperties.Builder object with the list of RtmpProperties setting.
          */
-        public Builder addRtmpProperties (RtmpProperties rtmpProps) throws InvalidArgumentException {
+        public Builder addRtmpProperties(RtmpProperties rtmpProps) throws InvalidArgumentException {
             if (this.rtmpList.size() >= 5) {
                 throw new InvalidArgumentException("Cannot add more than 5 RtmpProperties properties");
             }
@@ -207,6 +237,20 @@ public class BroadcastProperties {
     }
 
     /**
+     * Whether the broadcast has audio (<code>true</code>) or not (<code>false</code>).
+     */
+    public boolean hasAudio() {
+        return hasAudio;
+    }
+
+    /**
+     * Whether the broadcast has video (<code>true</code>) or not (<code>false</code>).
+     */
+    public boolean hasVideo() {
+        return hasVideo;
+    }
+
+    /**
      * The HLS configuration object, or <code>null</code> if {@link BroadcastProperties#hasHls} is false.
      */
     public Hls hls() {
@@ -219,6 +263,7 @@ public class BroadcastProperties {
     public List<RtmpProperties> rtmpList() {
         return rtmpList;
     }
+
     /**
      * Returns the resolution of the broadcast.
      */
@@ -236,5 +281,7 @@ public class BroadcastProperties {
     /**
      * The stream mode of the broadcast.
      */
-    public StreamMode streamMode() { return streamMode; }
+    public StreamMode streamMode() {
+        return streamMode;
+    }
 }

--- a/src/main/java/com/opentok/Hls.java
+++ b/src/main/java/com/opentok/Hls.java
@@ -13,7 +13,6 @@ package com.opentok;
  * {@link BroadcastProperties#hls()} method.
  */
 public class Hls {
-
 	private final boolean dvr;
 	private final boolean lowLatency;
 

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -500,6 +500,8 @@ public class HttpClient extends DefaultAsyncHttpClient {
         ObjectNode requestJson = nodeFactory.objectNode();
         requestJson.put("sessionId", sessionId);
         requestJson.put("streamMode", properties.streamMode().toString());
+        requestJson.put("hasAudio", properties.hasAudio());
+        requestJson.put("hasVideo", properties.hasVideo());
 
         if (properties.layout() != null) {
             ObjectNode layout = requestJson.putObject("layout");
@@ -568,7 +570,6 @@ public class HttpClient extends DefaultAsyncHttpClient {
                     throw new RequestException("Could not start an OpenTok Broadcast. A bad request, check input  properties like resolution etc.");
                 case 403:
                     throw new RequestException("Could not start an OpenTok Broadcast. The request was not authorized.");
-
                 case 409:
                     throw new RequestException("The broadcast has already been started for the session. SessionId = " + sessionId);
                 case 500:

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -1680,6 +1680,13 @@ public class OpenTokTest {
         String sessionId = "SESSIONID";
         String url = "/v2/project/" + this.apiKey + "/broadcast";
         stubFor(post(urlEqualTo(url))
+              .withRequestBody(equalTo("{\"sessionId\":\"SESSIONID\",\"streamMode\":\"auto\"," +
+                    "\"hasAudio\":false,\"hasVideo\":false,\"layout\":{\"type\":\"pip\"},\"maxDuration\":1000," +
+                    "\"resolution\":\"1920x1080\",\"multiBroadcastTag\":\"MyVideoBroadcastTag\",\"outputs\":{" +
+                    "\"hls\":{},\"rtmp\":[{\"id\":\"foo\",\"serverUrl\":\"rtmp://myfooserver/myfooapp\"," +
+                    "\"streamName\":\"myfoostream\"},{\"id\":\"bar\",\"serverUrl\":" +
+                    "\"rtmp://mybarserver/mybarapp\",\"streamName\":\"mybarstream\"}]}}"
+              ))
               .willReturn(aResponse()
                     .withStatus(200)
                     .withHeader("Content-Type", "application/json")
@@ -1688,7 +1695,9 @@ public class OpenTokTest {
                           "          \"sessionId\" : \"SESSIONID\",\n" +
                           "          \"projectId\" : 123456,\n" +
                           "          \"createdAt\" : 1437676551000,\n" +
-                          "          \"upDatedAt\" : 1437676551000,\n" +
+                          "          \"updatedAt\" : 1437676551000,\n" +
+                          "          \"hasAudio\" : false,\n" +
+                          "          \"hasVideo\" : false,\n" +
                           "          \"resolution\" : \"1280x720\",\n" +
                           "          \"status\" : \"started\",\n" +
                           "          \"multiBroadcastTag\" : \"MyVideoBroadcastTag\",\n" +
@@ -1717,7 +1726,8 @@ public class OpenTokTest {
               .addRtmpProperties(rtmpProps)
               .addRtmpProperties(rtmpNextProps)
               .maxDuration(1000)
-              .resolution("640x480")
+              .resolution("1920x1080")
+              .hasAudio(false).hasVideo(false)
               .multiBroadcastTag("MyVideoBroadcastTag")
               .layout(layout)
               .streamMode(Broadcast.StreamMode.AUTO)
@@ -1732,6 +1742,8 @@ public class OpenTokTest {
         assertNotNull(rtmp.getStreamName());
         assertNotNull(broadcast.toString());
         assertNotNull(broadcast.getStatus());
+        assertFalse(broadcast.hasAudio());
+        assertFalse(broadcast.hasVideo());
         assertEquals("1280x720", broadcast.getResolution());
         assertTrue(broadcast.getCreatedAt() > 0);
         assertTrue(broadcast.getUpdatedAt() > -1);
@@ -1839,7 +1851,7 @@ public class OpenTokTest {
                 .maxDuration(5400)
                 .layout(layout)
                 .build();
-        String expectedJson = String.format("{\"sessionId\":\"%s\",\"streamMode\":\"auto\",\"layout\":{\"type\":\"bestFit\",\"screenshareType\":\"pip\"},\"maxDuration\":5400,\"resolution\":\"640x480\",\"outputs\":{\"hls\":{},\"rtmp\":[]}}",sessionId);
+        String expectedJson = String.format("{\"sessionId\":\"%s\",\"streamMode\":\"auto\",\"hasAudio\":true,\"hasVideo\":true,\"layout\":{\"type\":\"bestFit\",\"screenshareType\":\"pip\"},\"maxDuration\":5400,\"resolution\":\"640x480\",\"outputs\":{\"hls\":{},\"rtmp\":[]}}",sessionId);
         Broadcast broadcast = sdk.startBroadcast(sessionId, properties);
         assertNotNull(broadcast);
         assertEquals(sessionId, broadcast.getSessionId());


### PR DESCRIPTION
As described in [the spec](https://github.com/opentok/api-review/commit/f82528f7753eea2333e25339edfa87840d5b33fc), this PR adds the `hasAudio` and `hasVideo` fields to Broadcast.