### PR TITLE
fix: Expect 204 when patching Broadcast and Archive streams

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = v4.13.1
+current_version = v4.13.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2023 Vonage.
+Copyright (c) 2014-2024 Vonage.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When you use Maven as your build tool, you can manage dependencies in the `pom.x
 <dependency>
     <groupId>com.tokbox</groupId>
     <artifactId>opentok-server-sdk</artifactId>
-    <version>4.13.1</version>
+    <version>4.13.2</version>
 </dependency>
 ```
 
@@ -44,7 +44,7 @@ When you use Gradle as your build tool, you can manage dependencies in the `buil
 
 ```groovy
 dependencies {
-  compile group: 'com.tokbox', name: 'opentok-server-sdk', version: '4.13.1'
+  compile group: 'com.tokbox', name: 'opentok-server-sdk', version: '4.13.2'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,18 +23,18 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.35.0'
+    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.35.1'
     testImplementation 'commons-fileupload:commons-fileupload:1.5'
     testImplementation 'net.minidev:json-smart:2.4.11'
     testImplementation 'com.google.guava:guava:32.0.1-jre'
 
     implementation 'commons-lang:commons-lang:2.6'
     implementation 'commons-codec:commons-codec:1.16.0'
-    implementation 'io.netty:netty-codec-http:4.1.100.Final'
-    implementation 'io.netty:netty-handler:4.1.100.Final'
+    implementation 'io.netty:netty-codec-http:4.1.104.Final'
+    implementation 'io.netty:netty-handler:4.1.104.Final'
     implementation 'org.asynchttpclient:async-http-client:2.12.3'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
-    implementation 'org.bitbucket.b_c:jose4j:0.9.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
+    implementation 'org.bitbucket.b_c:jose4j:0.9.4'
 }
 
 task sourcesJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 group = 'com.tokbox'
 archivesBaseName = 'opentok-server-sdk'
-version = '4.13.1'
+version = '4.13.2'
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 

--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -1,6 +1,6 @@
 #
 # OpenTok Java SDK
-# Copyright (C) 2023 Vonage.
+# Copyright (C) 2024 Vonage.
 # http://www.tokbox.com
 #
 # Licensed under The MIT License (MIT). See LICENSE file for more information.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
-#Mon Apr 05 14:22:26 EDT 2021
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
+#Thu Jan 04 09:44:51 GMT 2024
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/com/opentok/Archive.java
+++ b/src/main/java/com/opentok/Archive.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Archive.java
+++ b/src/main/java/com/opentok/Archive.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ArchiveLayout.java
+++ b/src/main/java/com/opentok/ArchiveLayout.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ArchiveLayout.java
+++ b/src/main/java/com/opentok/ArchiveLayout.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ArchiveList.java
+++ b/src/main/java/com/opentok/ArchiveList.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ArchiveList.java
+++ b/src/main/java/com/opentok/ArchiveList.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ArchiveMode.java
+++ b/src/main/java/com/opentok/ArchiveMode.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ArchiveMode.java
+++ b/src/main/java/com/opentok/ArchiveMode.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ArchiveProperties.java
+++ b/src/main/java/com/opentok/ArchiveProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ArchiveProperties.java
+++ b/src/main/java/com/opentok/ArchiveProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/AudioConnector.java
+++ b/src/main/java/com/opentok/AudioConnector.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/AudioConnector.java
+++ b/src/main/java/com/opentok/AudioConnector.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/AudioConnectorProperties.java
+++ b/src/main/java/com/opentok/AudioConnectorProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/AudioConnectorProperties.java
+++ b/src/main/java/com/opentok/AudioConnectorProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Broadcast.java
+++ b/src/main/java/com/opentok/Broadcast.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Broadcast.java
+++ b/src/main/java/com/opentok/Broadcast.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/BroadcastLayout.java
+++ b/src/main/java/com/opentok/BroadcastLayout.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/BroadcastLayout.java
+++ b/src/main/java/com/opentok/BroadcastLayout.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/BroadcastProperties.java
+++ b/src/main/java/com/opentok/BroadcastProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/BroadcastProperties.java
+++ b/src/main/java/com/opentok/BroadcastProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Caption.java
+++ b/src/main/java/com/opentok/Caption.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Caption.java
+++ b/src/main/java/com/opentok/Caption.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/CaptionProperties.java
+++ b/src/main/java/com/opentok/CaptionProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/CaptionProperties.java
+++ b/src/main/java/com/opentok/CaptionProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/CreatedSession.java
+++ b/src/main/java/com/opentok/CreatedSession.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/CreatedSession.java
+++ b/src/main/java/com/opentok/CreatedSession.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Hls.java
+++ b/src/main/java/com/opentok/Hls.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Hls.java
+++ b/src/main/java/com/opentok/Hls.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/MediaMode.java
+++ b/src/main/java/com/opentok/MediaMode.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/MediaMode.java
+++ b/src/main/java/com/opentok/MediaMode.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/MuteAllProperties.java
+++ b/src/main/java/com/opentok/MuteAllProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/MuteAllProperties.java
+++ b/src/main/java/com/opentok/MuteAllProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/OpenTok.java
+++ b/src/main/java/com/opentok/OpenTok.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Render.java
+++ b/src/main/java/com/opentok/Render.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Render.java
+++ b/src/main/java/com/opentok/Render.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/RenderProperties.java
+++ b/src/main/java/com/opentok/RenderProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/RenderProperties.java
+++ b/src/main/java/com/opentok/RenderProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/RenderStatus.java
+++ b/src/main/java/com/opentok/RenderStatus.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/RenderStatus.java
+++ b/src/main/java/com/opentok/RenderStatus.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Resolution.java
+++ b/src/main/java/com/opentok/Resolution.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Resolution.java
+++ b/src/main/java/com/opentok/Resolution.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Role.java
+++ b/src/main/java/com/opentok/Role.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Role.java
+++ b/src/main/java/com/opentok/Role.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Rtmp.java
+++ b/src/main/java/com/opentok/Rtmp.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Rtmp.java
+++ b/src/main/java/com/opentok/Rtmp.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/RtmpProperties.java
+++ b/src/main/java/com/opentok/RtmpProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/RtmpProperties.java
+++ b/src/main/java/com/opentok/RtmpProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ScreenShareLayoutType.java
+++ b/src/main/java/com/opentok/ScreenShareLayoutType.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/ScreenShareLayoutType.java
+++ b/src/main/java/com/opentok/ScreenShareLayoutType.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Session.java
+++ b/src/main/java/com/opentok/Session.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Session.java
+++ b/src/main/java/com/opentok/Session.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/SessionProperties.java
+++ b/src/main/java/com/opentok/SessionProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/SessionProperties.java
+++ b/src/main/java/com/opentok/SessionProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/SignalProperties.java
+++ b/src/main/java/com/opentok/SignalProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/SignalProperties.java
+++ b/src/main/java/com/opentok/SignalProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Sip.java
+++ b/src/main/java/com/opentok/Sip.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Sip.java
+++ b/src/main/java/com/opentok/Sip.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/SipProperties.java
+++ b/src/main/java/com/opentok/SipProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/SipProperties.java
+++ b/src/main/java/com/opentok/SipProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Stream.java
+++ b/src/main/java/com/opentok/Stream.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/Stream.java
+++ b/src/main/java/com/opentok/Stream.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/StreamList.java
+++ b/src/main/java/com/opentok/StreamList.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/StreamList.java
+++ b/src/main/java/com/opentok/StreamList.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/StreamListProperties.java
+++ b/src/main/java/com/opentok/StreamListProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/StreamListProperties.java
+++ b/src/main/java/com/opentok/StreamListProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/StreamProperties.java
+++ b/src/main/java/com/opentok/StreamProperties.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/StreamProperties.java
+++ b/src/main/java/com/opentok/StreamProperties.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/TokenOptions.java
+++ b/src/main/java/com/opentok/TokenOptions.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/TokenOptions.java
+++ b/src/main/java/com/opentok/TokenOptions.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok;

--- a/src/main/java/com/opentok/constants/DefaultApiUrl.java
+++ b/src/main/java/com/opentok/constants/DefaultApiUrl.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.constants;

--- a/src/main/java/com/opentok/constants/DefaultApiUrl.java
+++ b/src/main/java/com/opentok/constants/DefaultApiUrl.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.constants;

--- a/src/main/java/com/opentok/constants/DefaultUserAgent.java
+++ b/src/main/java/com/opentok/constants/DefaultUserAgent.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.constants;

--- a/src/main/java/com/opentok/constants/DefaultUserAgent.java
+++ b/src/main/java/com/opentok/constants/DefaultUserAgent.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.constants;

--- a/src/main/java/com/opentok/constants/Version.java
+++ b/src/main/java/com/opentok/constants/Version.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.constants;

--- a/src/main/java/com/opentok/constants/Version.java
+++ b/src/main/java/com/opentok/constants/Version.java
@@ -8,5 +8,5 @@
 package com.opentok.constants;
 
 public class Version {
-    public static final String VERSION = "4.13.1";
+    public static final String VERSION = "4.13.2";
 }

--- a/src/main/java/com/opentok/constants/Version.java
+++ b/src/main/java/com/opentok/constants/Version.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.constants;

--- a/src/main/java/com/opentok/constants/package-info.java
+++ b/src/main/java/com/opentok/constants/package-info.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.constants;

--- a/src/main/java/com/opentok/constants/package-info.java
+++ b/src/main/java/com/opentok/constants/package-info.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.constants;

--- a/src/main/java/com/opentok/exception/InvalidArgumentException.java
+++ b/src/main/java/com/opentok/exception/InvalidArgumentException.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.exception;

--- a/src/main/java/com/opentok/exception/InvalidArgumentException.java
+++ b/src/main/java/com/opentok/exception/InvalidArgumentException.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.exception;

--- a/src/main/java/com/opentok/exception/OpenTokException.java
+++ b/src/main/java/com/opentok/exception/OpenTokException.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.exception;

--- a/src/main/java/com/opentok/exception/OpenTokException.java
+++ b/src/main/java/com/opentok/exception/OpenTokException.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.exception;

--- a/src/main/java/com/opentok/exception/RequestException.java
+++ b/src/main/java/com/opentok/exception/RequestException.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.exception;

--- a/src/main/java/com/opentok/exception/RequestException.java
+++ b/src/main/java/com/opentok/exception/RequestException.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.exception;

--- a/src/main/java/com/opentok/exception/package-info.java
+++ b/src/main/java/com/opentok/exception/package-info.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 /**

--- a/src/main/java/com/opentok/exception/package-info.java
+++ b/src/main/java/com/opentok/exception/package-info.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 /**

--- a/src/main/java/com/opentok/package-info.java
+++ b/src/main/java/com/opentok/package-info.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 /**

--- a/src/main/java/com/opentok/package-info.java
+++ b/src/main/java/com/opentok/package-info.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 /**

--- a/src/main/java/com/opentok/util/Crypto.java
+++ b/src/main/java/com/opentok/util/Crypto.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.util;

--- a/src/main/java/com/opentok/util/Crypto.java
+++ b/src/main/java/com/opentok/util/Crypto.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.util;

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.util;

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.util;

--- a/src/main/java/com/opentok/util/HttpClient.java
+++ b/src/main/java/com/opentok/util/HttpClient.java
@@ -338,7 +338,7 @@ public class HttpClient extends DefaultAsyncHttpClient {
         try {
             Response response = request.get();
             switch (response.getStatusCode()) {
-                case 200:
+                case 204:
                     return response.getResponseBody();
                 case 400:
                     throw new RequestException("Could not patch opentok archive. A invalid request. Check input properties.");
@@ -667,7 +667,7 @@ public class HttpClient extends DefaultAsyncHttpClient {
         try {
             Response response = request.get();
             switch (response.getStatusCode()) {
-                case 200:
+                case 204:
                     return response.getResponseBody();
                 case 400:
                     throw new RequestException("Could not patch opentok broadcast. A invalid request. Check input properties.");

--- a/src/main/java/com/opentok/util/TokenGenerator.java
+++ b/src/main/java/com/opentok/util/TokenGenerator.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.util;

--- a/src/main/java/com/opentok/util/TokenGenerator.java
+++ b/src/main/java/com/opentok/util/TokenGenerator.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.util;

--- a/src/test/java/com/opentok/test/Helpers.java
+++ b/src/test/java/com/opentok/test/Helpers.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.test;

--- a/src/test/java/com/opentok/test/Helpers.java
+++ b/src/test/java/com/opentok/test/Helpers.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.test;

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -698,12 +698,11 @@ public class OpenTokTest {
     }
 
     @Test
-    public void testPatchArchived() throws OpenTokException {
+    public void testPatchArchive() throws OpenTokException {
         String archiveId = "ARCHIVEID";
         String streamId = "abc123efg456";
         stubFor(patch(urlEqualTo(archivePath + "/" + archiveId + "/streams"))
-              .willReturn(aResponse()
-                    .withStatus(200)));
+              .willReturn(aResponse().withStatus(204)));
         sdk.addArchiveStream(archiveId, streamId, true, true);
         verify(patchRequestedFor(urlMatching(archivePath + "/" + archiveId + "/streams")));
         assertTrue(Helpers.verifyTokenAuth(apiKey, apiSecret,
@@ -712,7 +711,7 @@ public class OpenTokTest {
     }
 
     @Test
-    public void testPatchArchivedExpectException() throws OpenTokException {
+    public void testPatchArchiveExpectException() throws OpenTokException {
         String archiveId = "ARCHIVEID";
         Exception exception = assertThrows(OpenTokException.class, () -> sdk.removeArchiveStream(archiveId, ""));
         String got = exception.getMessage();
@@ -2140,8 +2139,7 @@ public class OpenTokTest {
         String broadcastId = "BROADCASTID";
         String streamId = "abc123efg456";
         stubFor(patch(urlEqualTo(broadcastPath + "/" + broadcastId + "/streams"))
-              .willReturn(aResponse()
-                    .withStatus(200)));
+              .willReturn(aResponse().withStatus(204)));
         sdk.addBroadcastStream(broadcastId, streamId, true, true);
         verify(patchRequestedFor(urlMatching(broadcastPath + "/" + broadcastId + "/streams")));
         assertTrue(Helpers.verifyTokenAuth(apiKey, apiSecret,

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -1,8 +1,8 @@
 /**
  * OpenTok Java SDK
- * Copyright (C) 2023 Vonage.
+ * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- *
+ * <p>
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.test;

--- a/src/test/java/com/opentok/test/OpenTokTest.java
+++ b/src/test/java/com/opentok/test/OpenTokTest.java
@@ -2,7 +2,7 @@
  * OpenTok Java SDK
  * Copyright (C) 2024 Vonage.
  * http://www.tokbox.com
- * <p>
+ * 
  * Licensed under The MIT License (MIT). See LICENSE file for more information.
  */
 package com.opentok.test;


### PR DESCRIPTION
Fixes the patch endpoint for archive and broadcast streams so that a 204 response is expected instead of 200. Also bumps dependency versions.