### PR TITLE
docs: Link to Vonage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ The OpenTok Java SDK provides methods for:
 * Working with [Experience Composers](https://tokbox.com/developer/guides/experience-composer)
 * Working with [Audio Connectors](/https://tokbox.com/developer/guides/audio-connector)
 
+## Note!
+
+This library is designed to work with the Tokbox/OpenTok platform, part of the Vonage Video API. If you are looking to use the Vonage Video API and using the Vonage Customer Dashboard, you will want to install the [Vonage Server SDK for Java](https://github.com/Vonage/vonage-java-sdk), which includes support for the Vonage Video API.
+
+Not sure which exact platform you are using? Take a look at [this guide](https://api.support.vonage.com/hc/en-us/articles/10817774782492).
+
+If you are using the Tokbox platform, do not worry! The Tokbox platform is not going away, and this library will continue to be updated. While we encourage customers to check out the new Unified platform, there is no rush to switch. Both platforms run the exact same infrastructure and capabilities, with the main difference is a unified billing interface and easier access to [Vonage’s other CPaaS APIs](https://www.vonage.com/communications-apis/).
+
+If you are new to the Vonage Video API, head on over to the [Vonage Customer Dashboard](https://dashboard.vonage.com) to sign up for a developer account and check out the [Vonage Server SDK for Java](https://github.com/Vonage/vonage-java-sdk).
+
+
 ## Installation
 
 ### Maven Central (recommended):


### PR DESCRIPTION
New customers should sign up for Vonage instead of OpenTok. This is noted in README.md.