### PR TITLE
ci: Update test dependencies & runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,11 @@ name: Build Java CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
-  build:
+  build_only:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -28,7 +28,37 @@ jobs:
         run: chmod +x gradlew
 
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [21]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -38,4 +68,4 @@ jobs:
         run: ./gradlew build
 
       - name: Run Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.target_commitish }}
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,6 @@ plugins {
 group = 'com.tokbox'
 archivesBaseName = 'opentok-server-sdk'
 version = '4.14.0'
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
 
 ext.githubPath = 'opentok/opentok-java-sdk'
 
@@ -23,10 +21,9 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.35.2'
-    testImplementation 'commons-fileupload:commons-fileupload:1.5'
+    testImplementation 'org.wiremock:wiremock:3.5.3'
     testImplementation 'net.minidev:json-smart:2.5.1'
-    testImplementation 'com.google.guava:guava:32.1.3-jre'
+    testImplementation 'com.google.guava:guava:33.1.0-jre'
 
     implementation 'commons-lang:commons-lang:2.6'
     implementation 'commons-codec:commons-codec:1.16.1'
@@ -35,6 +32,16 @@ dependencies {
     implementation 'org.asynchttpclient:async-http-client:2.12.3'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
     implementation 'org.bitbucket.b_c:jose4j:0.9.6'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = sourceCompatibility
+}
+
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = sourceCompatibility
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
This PR updates the tests to run on Java 21 and the GitHub workflows to accomodate this, similar to how the Vonage Server SDK works.