### PR TITLE
Fix links in the published POM file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ publishing {
                 licenses {
                     license {
                         name = 'MIT License'
-                        url = "https://raw.github.com/$githubPath/main/LICENCE.txt"
+                        url = "https://raw.github.com/$githubPath/refs/heads/main/LICENSE"
                     }
                 }
                 developers {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ group = 'com.tokbox'
 archivesBaseName = 'opentok-server-sdk'
 version = '4.15.0'
 
-ext.githubPath = "opentok/$archivesBaseName"
+ext.githubPath = "opentok/Opentok-Java-SDK"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
The published POM file on maven central:
https://repo1.maven.org/maven2/com/tokbox/opentok-server-sdk/4.15.0/opentok-server-sdk-4.15.0.pom

Contains links like:

```xml
<url>https://github.com/opentok/opentok-server-sdk</url>
```

```xml
<license>
  <name>MIT License</name>
  <url>https://raw.github.com/opentok/opentok-server-sdk/main/LICENCE.txt</url>
</license>
```

```xml
<scm>
   <connection>scm:git@github.com/opentok/opentok-server-sdk</connection>
   <developerConnection>scm:git@github.com/opentok/opentok-server-sdk</developerConnection>
   <url>https://github.com/opentok/opentok-server-sdk</url>
</scm>
```

Those links are broken.

They were correct in the POM of version `4.14.0`:
 https://repo1.maven.org/maven2/com/tokbox/opentok-server-sdk/4.14.0/opentok-server-sdk-4.14.0.pom

The problematic change was introduced by https://github.com/opentok/Opentok-Java-SDK/pull/255

With this PR I suggest to revert the change to the problematic line.